### PR TITLE
Backport swap() -> V_swap() rename to avoid C++11 ADL ambiguity errors

### DIFF
--- a/game/client/cdll_util.cpp
+++ b/game/client/cdll_util.cpp
@@ -943,7 +943,7 @@ static unsigned char ComputeDistanceFade( C_BaseEntity *pEntity, float flMinDist
 
 	if( flMinDist > flMaxDist )
 	{
-		swap( flMinDist, flMaxDist );
+		::V_swap( flMinDist, flMaxDist );
 	}
 
 	// If a negative value is provided for the min fade distance, then base it off the max.

--- a/game/client/clientleafsystem.cpp
+++ b/game/client/clientleafsystem.cpp
@@ -1722,8 +1722,8 @@ void CClientLeafSystem::SortEntities( const Vector &vecRenderOrigin, const Vecto
 		{
 			if( dists[i] > dists[i+stepSize] )
 			{
-				swap( pEntities[i], pEntities[i+stepSize] );
-				swap( dists[i], dists[i+stepSize] );
+				::V_swap( pEntities[i], pEntities[i+stepSize] );
+				::V_swap( dists[i], dists[i+stepSize] );
 
 				if( i == 0 )
 				{

--- a/game/client/clientshadowmgr.cpp
+++ b/game/client/clientshadowmgr.cpp
@@ -1138,7 +1138,7 @@ void CVisibleShadowList::PrioritySort()
 				flLargestArea = m_ShadowsInView[nIndex].m_flArea;
 			}
 		}
-		swap( m_PriorityIndex[i], m_PriorityIndex[nLargestInd] );
+		::V_swap( m_PriorityIndex[i], m_PriorityIndex[nLargestInd] );
 	}
 }
 

--- a/game/client/detailobjectsystem.cpp
+++ b/game/client/detailobjectsystem.cpp
@@ -1613,7 +1613,7 @@ void CDetailObjectSystem::UnserializeDetailSprites( CUtlBuffer& buf )
 		buf.Get( &m_DetailSpriteDict[i], sizeof(DetailSpriteDictLump_t) );
 		int flipi = m_DetailSpriteDictFlipped.AddToTail();
 		m_DetailSpriteDictFlipped[flipi] = m_DetailSpriteDict[i];
-		swap( m_DetailSpriteDictFlipped[flipi].m_TexUL.x, m_DetailSpriteDictFlipped[flipi].m_TexLR.x );
+		::V_swap( m_DetailSpriteDictFlipped[flipi].m_TexUL.x, m_DetailSpriteDictFlipped[flipi].m_TexLR.x );
 	}
 }
 

--- a/game/server/episodic/npc_advisor.cpp
+++ b/game/server/episodic/npc_advisor.cpp
@@ -821,7 +821,7 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 				// swap them if necessary (1 must be the bottom)
 				if (m_levitateCallback.m_vecGoalPos1.z > m_levitateCallback.m_vecGoalPos2.z)
 				{
-					swap(m_levitateCallback.m_vecGoalPos1,m_levitateCallback.m_vecGoalPos2);
+					::V_swap(m_levitateCallback.m_vecGoalPos1,m_levitateCallback.m_vecGoalPos2);
 				}
 
 				m_levitateCallback.m_flFloat = 0.06f; // this is an absolute accumulation upon gravity

--- a/game/server/episodic/npc_advisor.cpp
+++ b/game/server/episodic/npc_advisor.cpp
@@ -821,7 +821,7 @@ void CNPC_Advisor::RunTask( const Task_t *pTask )
 				// swap them if necessary (1 must be the bottom)
 				if (m_levitateCallback.m_vecGoalPos1.z > m_levitateCallback.m_vecGoalPos2.z)
 				{
-					::V_swap(m_levitateCallback.m_vecGoalPos1,m_levitateCallback.m_vecGoalPos2);
+					V_swap(m_levitateCallback.m_vecGoalPos1,m_levitateCallback.m_vecGoalPos2);
 				}
 
 				m_levitateCallback.m_flFloat = 0.06f; // this is an absolute accumulation upon gravity

--- a/game/server/episodic/vehicle_jeep_episodic.cpp
+++ b/game/server/episodic/vehicle_jeep_episodic.cpp
@@ -1626,13 +1626,13 @@ void CPropJeepEpisodic::InputOutsideTransition( inputdata_t &inputdata )
 		VectorRotate( vecSurroundMaxs, vecTeleportAngles, vecMaxs );
 
 		if ( vecMaxs.x < vecMins.x )
-			swap( vecMins.x, vecMaxs.x );
+			::V_swap( vecMins.x, vecMaxs.x );
 
 		if ( vecMaxs.y < vecMins.y )
-			swap( vecMins.y, vecMaxs.y );
+			::V_swap( vecMins.y, vecMaxs.y );
 
 		if ( vecMaxs.z < vecMins.z )
-			swap( vecMins.z, vecMaxs.z );
+			::V_swap( vecMins.z, vecMaxs.z );
 
 		// Move up
 		vecTeleportPos.z += ( vecMaxs.z - vecMins.z );

--- a/game/server/episodic/vehicle_jeep_episodic.cpp
+++ b/game/server/episodic/vehicle_jeep_episodic.cpp
@@ -1626,13 +1626,13 @@ void CPropJeepEpisodic::InputOutsideTransition( inputdata_t &inputdata )
 		VectorRotate( vecSurroundMaxs, vecTeleportAngles, vecMaxs );
 
 		if ( vecMaxs.x < vecMins.x )
-			::V_swap( vecMins.x, vecMaxs.x );
+			V_swap( vecMins.x, vecMaxs.x );
 
 		if ( vecMaxs.y < vecMins.y )
-			::V_swap( vecMins.y, vecMaxs.y );
+			V_swap( vecMins.y, vecMaxs.y );
 
 		if ( vecMaxs.z < vecMins.z )
-			::V_swap( vecMins.z, vecMaxs.z );
+			V_swap( vecMins.z, vecMaxs.z );
 
 		// Move up
 		vecTeleportPos.z += ( vecMaxs.z - vecMins.z );

--- a/game/server/filters.cpp
+++ b/game/server/filters.cpp
@@ -536,7 +536,7 @@ bool CFilterEnemy::PassesProximityFilter( CBaseEntity *pCaller, CBaseEntity *pEn
 	float flSmallerRadius = m_flRadius;
 	if ( flSmallerRadius > flLargerRadius )
 	{
-		swap( flLargerRadius, flSmallerRadius );
+		::V_swap( flLargerRadius, flSmallerRadius );
 	}
 
 	float flDist;	

--- a/game/server/hl2/npc_attackchopper.cpp
+++ b/game/server/hl2/npc_attackchopper.cpp
@@ -1843,7 +1843,7 @@ void CNPC_AttackHelicopter::ShootAtPlayer( const Vector &vBasePos, const Vector 
 	for ( i = 0; i < nActualTargets; ++i )
 	{
 		int nSwap = random->RandomInt( 0, nActualTargets - 1 ); 
-		swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
+		::V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
 	}
 
 	// Just shoot where we're facing
@@ -2120,7 +2120,7 @@ void CNPC_AttackHelicopter::ShootAtVehicle( const Vector &vBasePos, const Vector
 	for ( i = 0; i < nActualTargets; ++i )
 	{
 		int nSwap = random->RandomInt( 0, nActualTargets - 1 ); 
-		swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
+		::V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
 	}
 
 	// Just shoot where we're facing

--- a/game/server/hl2/npc_attackchopper.cpp
+++ b/game/server/hl2/npc_attackchopper.cpp
@@ -1843,7 +1843,7 @@ void CNPC_AttackHelicopter::ShootAtPlayer( const Vector &vBasePos, const Vector 
 	for ( i = 0; i < nActualTargets; ++i )
 	{
 		int nSwap = random->RandomInt( 0, nActualTargets - 1 ); 
-		::V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
+		V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
 	}
 
 	// Just shoot where we're facing
@@ -2120,7 +2120,7 @@ void CNPC_AttackHelicopter::ShootAtVehicle( const Vector &vBasePos, const Vector
 	for ( i = 0; i < nActualTargets; ++i )
 	{
 		int nSwap = random->RandomInt( 0, nActualTargets - 1 ); 
-		::V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
+		V_swap( ppNearbyTargets[i], ppNearbyTargets[nSwap] );
 	}
 
 	// Just shoot where we're facing

--- a/game/server/hl2/npc_combinecamera.cpp
+++ b/game/server/hl2/npc_combinecamera.cpp
@@ -355,7 +355,7 @@ void CNPC_CombineCamera::Spawn()
 
 	if (m_nOuterRadius < m_nInnerRadius)
 	{
-		swap(m_nOuterRadius, m_nInnerRadius);
+		::V_swap(m_nOuterRadius, m_nInnerRadius);
 	}
 
 	// Do we start active?
@@ -1117,17 +1117,17 @@ void CNPC_CombineCamera::SetHeight(float height)
 
 	if (mins.x > maxs.x)
 	{
-		swap(mins.x, maxs.x);
+		::V_swap(mins.x, maxs.x);
 	}
 
 	if (mins.y > maxs.y)
 	{
-		swap(mins.y, maxs.y);
+		::V_swap(mins.y, maxs.y);
 	}
 
 	if (mins.z > maxs.z)
 	{
-		swap(mins.z, maxs.z);
+		::V_swap(mins.z, maxs.z);
 	}
 
 	SetCollisionBounds(mins, maxs);

--- a/game/server/hl2/npc_combinecamera.cpp
+++ b/game/server/hl2/npc_combinecamera.cpp
@@ -355,7 +355,7 @@ void CNPC_CombineCamera::Spawn()
 
 	if (m_nOuterRadius < m_nInnerRadius)
 	{
-		::V_swap(m_nOuterRadius, m_nInnerRadius);
+		V_swap(m_nOuterRadius, m_nInnerRadius);
 	}
 
 	// Do we start active?
@@ -1117,17 +1117,17 @@ void CNPC_CombineCamera::SetHeight(float height)
 
 	if (mins.x > maxs.x)
 	{
-		::V_swap(mins.x, maxs.x);
+		V_swap(mins.x, maxs.x);
 	}
 
 	if (mins.y > maxs.y)
 	{
-		::V_swap(mins.y, maxs.y);
+		V_swap(mins.y, maxs.y);
 	}
 
 	if (mins.z > maxs.z)
 	{
-		::V_swap(mins.z, maxs.z);
+		V_swap(mins.z, maxs.z);
 	}
 
 	SetCollisionBounds(mins, maxs);

--- a/game/server/hl2/npc_turret_ceiling.cpp
+++ b/game/server/hl2/npc_turret_ceiling.cpp
@@ -1093,17 +1093,17 @@ void CNPC_CeilingTurret::SetHeight( float height )
 
 	if ( mins.x > maxs.x )
 	{
-		::V_swap( mins.x, maxs.x );
+		V_swap( mins.x, maxs.x );
 	}
 
 	if ( mins.y > maxs.y )
 	{
-		::V_swap( mins.y, maxs.y );
+		V_swap( mins.y, maxs.y );
 	}
 
 	if ( mins.z > maxs.z )
 	{
-		::V_swap( mins.z, maxs.z );
+		V_swap( mins.z, maxs.z );
 	}
 
 	SetCollisionBounds( mins, maxs );

--- a/game/server/hl2/npc_turret_ceiling.cpp
+++ b/game/server/hl2/npc_turret_ceiling.cpp
@@ -1093,17 +1093,17 @@ void CNPC_CeilingTurret::SetHeight( float height )
 
 	if ( mins.x > maxs.x )
 	{
-		swap( mins.x, maxs.x );
+		::V_swap( mins.x, maxs.x );
 	}
 
 	if ( mins.y > maxs.y )
 	{
-		swap( mins.y, maxs.y );
+		::V_swap( mins.y, maxs.y );
 	}
 
 	if ( mins.z > maxs.z )
 	{
-		swap( mins.z, maxs.z );
+		::V_swap( mins.z, maxs.z );
 	}
 
 	SetCollisionBounds( mins, maxs );

--- a/game/server/hltvdirector.cpp
+++ b/game/server/hltvdirector.cpp
@@ -562,7 +562,7 @@ void CHLTVDirector::CreateShotFromEvent( CGameEvent *event )
 			// if we show ineye view, show it more likely from killer
 			if ( RandomFloat(0,1) > (bInEye?0.3f:0.7f)  )
 			{
-				swap( attacker, victim );
+				::V_swap( attacker, victim );
 			}
 						
 			// hurting a victim is shown as chase more often

--- a/game/server/physconstraint.cpp
+++ b/game/server/physconstraint.cpp
@@ -1280,7 +1280,7 @@ IPhysicsConstraint *CPhysSlideConstraint::CreateConstraint( IPhysicsConstraintGr
 		sliding.limitMax = DotProduct( axisDirection, m_axisEnd );
 		if ( sliding.limitMax < sliding.limitMin )
 		{
-			swap( sliding.limitMin, sliding.limitMax );
+			::V_swap( sliding.limitMin, sliding.limitMax );
 		}
 
 		// expand limits to make initial position of the attached object valid

--- a/game/server/props.cpp
+++ b/game/server/props.cpp
@@ -4789,7 +4789,7 @@ void CPropDoorRotating::Spawn()
 	// that the model already be set.
 	if ( IsHingeOnLeft() )
 	{
-		swap( m_angRotationOpenForward, m_angRotationOpenBack );
+		::V_swap( m_angRotationOpenForward, m_angRotationOpenBack );
 	}
 
 	// Figure out our volumes of movement as this door opens

--- a/game/shared/gamerules.cpp
+++ b/game/shared/gamerules.cpp
@@ -637,7 +637,7 @@ bool CGameRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 	if ( collisionGroup0 > collisionGroup1 )
 	{
 		// swap so that lowest is always first
-		swap(collisionGroup0,collisionGroup1);
+		::V_swap(collisionGroup0,collisionGroup1);
 	}
 
 #ifndef HL2MP

--- a/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -866,7 +866,7 @@ bool CHL2MPRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 	if ( collisionGroup0 > collisionGroup1 )
 	{
 		// swap so that lowest is always first
-		::V_swap(collisionGroup0,collisionGroup1);
+		V_swap(collisionGroup0,collisionGroup1);
 	}
 
 	if ( (collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) &&

--- a/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -866,7 +866,7 @@ bool CHL2MPRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 	if ( collisionGroup0 > collisionGroup1 )
 	{
 		// swap so that lowest is always first
-		swap(collisionGroup0,collisionGroup1);
+		::V_swap(collisionGroup0,collisionGroup1);
 	}
 
 	if ( (collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) &&

--- a/game/shared/sdk/sdk_gamerules.cpp
+++ b/game/shared/sdk/sdk_gamerules.cpp
@@ -295,7 +295,7 @@ bool CSDKGameRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 	if ( collisionGroup0 > collisionGroup1 )
 	{
 		// swap so that lowest is always first
-		swap(collisionGroup0,collisionGroup1);
+		::V_swap(collisionGroup0,collisionGroup1);
 	}
 	
 	//Don't stand on COLLISION_GROUP_WEAPON

--- a/game/shared/sdk/sdk_gamerules.cpp
+++ b/game/shared/sdk/sdk_gamerules.cpp
@@ -295,7 +295,7 @@ bool CSDKGameRules::ShouldCollide( int collisionGroup0, int collisionGroup1 )
 	if ( collisionGroup0 > collisionGroup1 )
 	{
 		// swap so that lowest is always first
-		::V_swap(collisionGroup0,collisionGroup1);
+		V_swap(collisionGroup0,collisionGroup1);
 	}
 	
 	//Don't stand on COLLISION_GROUP_WEAPON

--- a/mathlib/mathlib_base.cpp
+++ b/mathlib/mathlib_base.cpp
@@ -380,9 +380,9 @@ void MatrixInvert( const matrix3x4_t& in, matrix3x4_t& out )
 	Assert( s_bMathlibInitialized );
 	if ( &in == &out )
 	{
-		::V_swap(out[0][1],out[1][0]);
-		::V_swap(out[0][2],out[2][0]);
-		::V_swap(out[1][2],out[2][1]);
+		V_swap(out[0][1],out[1][0]);
+		V_swap(out[0][2],out[2][0]);
+		V_swap(out[1][2],out[2][1]);
 	}
 	else
 	{
@@ -1264,18 +1264,18 @@ bool SolveInverseQuadraticMonotonic( float x1, float y1, float x2, float y2, flo
 	// first, sort parameters
 	if (x1>x2)
 	{
-		::V_swap(x1,x2);
-		::V_swap(y1,y2);
+		V_swap(x1,x2);
+		V_swap(y1,y2);
 	}
 	if (x2>x3)
 	{
-		::V_swap(x2,x3);
-		::V_swap(y2,y3);
+		V_swap(x2,x3);
+		V_swap(y2,y3);
 	}
 	if (x1>x2)
 	{
-		::V_swap(x1,x2);
-		::V_swap(y1,y2);
+		V_swap(x1,x2);
+		V_swap(y1,y2);
 	}
 	// this code is not fast. what it does is when the curve would be non-monotonic, slowly shifts
 	// the center point closer to the linear line between the endpoints. Should anyone need htis

--- a/mathlib/mathlib_base.cpp
+++ b/mathlib/mathlib_base.cpp
@@ -380,9 +380,9 @@ void MatrixInvert( const matrix3x4_t& in, matrix3x4_t& out )
 	Assert( s_bMathlibInitialized );
 	if ( &in == &out )
 	{
-		swap(out[0][1],out[1][0]);
-		swap(out[0][2],out[2][0]);
-		swap(out[1][2],out[2][1]);
+		::V_swap(out[0][1],out[1][0]);
+		::V_swap(out[0][2],out[2][0]);
+		::V_swap(out[1][2],out[2][1]);
 	}
 	else
 	{
@@ -1264,18 +1264,18 @@ bool SolveInverseQuadraticMonotonic( float x1, float y1, float x2, float y2, flo
 	// first, sort parameters
 	if (x1>x2)
 	{
-		swap(x1,x2);
-		swap(y1,y2);
+		::V_swap(x1,x2);
+		::V_swap(y1,y2);
 	}
 	if (x2>x3)
 	{
-		swap(x2,x3);
-		swap(y2,y3);
+		::V_swap(x2,x3);
+		::V_swap(y2,y3);
 	}
 	if (x1>x2)
 	{
-		swap(x1,x2);
-		swap(y1,y2);
+		::V_swap(x1,x2);
+		::V_swap(y1,y2);
 	}
 	// this code is not fast. what it does is when the curve would be non-monotonic, slowly shifts
 	// the center point closer to the linear line between the endpoints. Should anyone need htis

--- a/public/mathlib/mathlib.h
+++ b/public/mathlib/mathlib.h
@@ -606,9 +606,9 @@ template<> FORCEINLINE QAngleByValue Lerp<QAngleByValue>( float flPercent, const
 #endif // VECTOR_NO_SLOW_OPERATIONS
 
 
-// Swap two of anything.
+/// Same as swap(), but won't cause problems with std::swap
 template <class T> 
-FORCEINLINE void swap( T& x, T& y )
+FORCEINLINE void V_swap( T& x, T& y )
 {
 	T temp = x;
 	x = y;

--- a/public/particles/particles.h
+++ b/public/particles/particles.h
@@ -1452,7 +1452,7 @@ inline void CParticleCollection::SwapPosAndPrevPos( void )
 {
 	// strides better be the same!
 	Assert( m_nParticleFloatStrides[PARTICLE_ATTRIBUTE_XYZ] == m_nParticleFloatStrides[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
-	::V_swap( m_pParticleAttributes[ PARTICLE_ATTRIBUTE_XYZ ], m_pParticleAttributes[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
+	V_swap( m_pParticleAttributes[ PARTICLE_ATTRIBUTE_XYZ ], m_pParticleAttributes[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
 }
 
 inline void CParticleCollection::LoanKillListTo( CParticleCollection *pBorrower ) const

--- a/public/particles/particles.h
+++ b/public/particles/particles.h
@@ -1452,7 +1452,7 @@ inline void CParticleCollection::SwapPosAndPrevPos( void )
 {
 	// strides better be the same!
 	Assert( m_nParticleFloatStrides[PARTICLE_ATTRIBUTE_XYZ] == m_nParticleFloatStrides[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
-	swap( m_pParticleAttributes[ PARTICLE_ATTRIBUTE_XYZ ], m_pParticleAttributes[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
+	::V_swap( m_pParticleAttributes[ PARTICLE_ATTRIBUTE_XYZ ], m_pParticleAttributes[ PARTICLE_ATTRIBUTE_PREV_XYZ ] );
 }
 
 inline void CParticleCollection::LoanKillListTo( CParticleCollection *pBorrower ) const

--- a/public/tier1/utlblockmemory.h
+++ b/public/tier1/utlblockmemory.h
@@ -137,10 +137,10 @@ CUtlBlockMemory<T,I>::~CUtlBlockMemory()
 template< class T, class I >
 void CUtlBlockMemory<T,I>::Swap( CUtlBlockMemory< T, I > &mem )
 {
-	swap( m_pMemory, mem.m_pMemory );
-	swap( m_nBlocks, mem.m_nBlocks );
-	swap( m_nIndexMask, mem.m_nIndexMask );
-	swap( m_nIndexShift, mem.m_nIndexShift );
+	::V_swap( m_pMemory, mem.m_pMemory );
+	::V_swap( m_nBlocks, mem.m_nBlocks );
+	::V_swap( m_nIndexMask, mem.m_nIndexMask );
+	::V_swap( m_nIndexShift, mem.m_nIndexShift );
 }
 
 

--- a/public/tier1/utlblockmemory.h
+++ b/public/tier1/utlblockmemory.h
@@ -137,10 +137,10 @@ CUtlBlockMemory<T,I>::~CUtlBlockMemory()
 template< class T, class I >
 void CUtlBlockMemory<T,I>::Swap( CUtlBlockMemory< T, I > &mem )
 {
-	::V_swap( m_pMemory, mem.m_pMemory );
-	::V_swap( m_nBlocks, mem.m_nBlocks );
-	::V_swap( m_nIndexMask, mem.m_nIndexMask );
-	::V_swap( m_nIndexShift, mem.m_nIndexShift );
+	V_swap( m_pMemory, mem.m_pMemory );
+	V_swap( m_nBlocks, mem.m_nBlocks );
+	V_swap( m_nIndexMask, mem.m_nIndexMask );
+	V_swap( m_nIndexShift, mem.m_nIndexShift );
 }
 
 

--- a/public/tier1/utlfixedmemory.h
+++ b/public/tier1/utlfixedmemory.h
@@ -181,9 +181,9 @@ CUtlFixedMemory<T>::~CUtlFixedMemory()
 template< class T >
 void CUtlFixedMemory<T>::Swap( CUtlFixedMemory< T > &mem )
 {
-	swap( m_pBlocks, mem.m_pBlocks );
-	swap( m_nAllocationCount, mem.m_nAllocationCount );
-	swap( m_nGrowSize, mem.m_nGrowSize );
+	::V_swap( m_pBlocks, mem.m_pBlocks );
+	::V_swap( m_nAllocationCount, mem.m_nAllocationCount );
+	::V_swap( m_nGrowSize, mem.m_nGrowSize );
 }
 
 

--- a/public/tier1/utlfixedmemory.h
+++ b/public/tier1/utlfixedmemory.h
@@ -181,9 +181,9 @@ CUtlFixedMemory<T>::~CUtlFixedMemory()
 template< class T >
 void CUtlFixedMemory<T>::Swap( CUtlFixedMemory< T > &mem )
 {
-	::V_swap( m_pBlocks, mem.m_pBlocks );
-	::V_swap( m_nAllocationCount, mem.m_nAllocationCount );
-	::V_swap( m_nGrowSize, mem.m_nGrowSize );
+	V_swap( m_pBlocks, mem.m_pBlocks );
+	V_swap( m_nAllocationCount, mem.m_nAllocationCount );
+	V_swap( m_nGrowSize, mem.m_nGrowSize );
 }
 
 

--- a/public/tier1/utlmemory.h
+++ b/public/tier1/utlmemory.h
@@ -327,9 +327,9 @@ void CUtlMemory<T,I>::Init( int nGrowSize /*= 0*/, int nInitSize /*= 0*/ )
 template< class T, class I >
 void CUtlMemory<T,I>::Swap( CUtlMemory<T,I> &mem )
 {
-	::V_swap( m_nGrowSize, mem.m_nGrowSize );
-	::V_swap( m_pMemory, mem.m_pMemory );
-	::V_swap( m_nAllocationCount, mem.m_nAllocationCount );
+	V_swap( m_nGrowSize, mem.m_nGrowSize );
+	V_swap( m_pMemory, mem.m_pMemory );
+	V_swap( m_nAllocationCount, mem.m_nAllocationCount );
 }
 
 

--- a/public/tier1/utlmemory.h
+++ b/public/tier1/utlmemory.h
@@ -327,9 +327,9 @@ void CUtlMemory<T,I>::Init( int nGrowSize /*= 0*/, int nInitSize /*= 0*/ )
 template< class T, class I >
 void CUtlMemory<T,I>::Swap( CUtlMemory<T,I> &mem )
 {
-	swap( m_nGrowSize, mem.m_nGrowSize );
-	swap( m_pMemory, mem.m_pMemory );
-	swap( m_nAllocationCount, mem.m_nAllocationCount );
+	::V_swap( m_nGrowSize, mem.m_nGrowSize );
+	::V_swap( m_pMemory, mem.m_pMemory );
+	::V_swap( m_nAllocationCount, mem.m_nAllocationCount );
 }
 
 

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -1547,12 +1547,12 @@ template < class T, class I, typename L, class M >
 void CUtlRBTree<T, I, L, M>::Swap( CUtlRBTree< T, I, L > &that )
 {
 	m_Elements.Swap( that.m_Elements );
-	::V_swap( m_LessFunc, that.m_LessFunc );
-	::V_swap( m_Root, that.m_Root );
-	::V_swap( m_NumElements, that.m_NumElements );
-	::V_swap( m_FirstFree, that.m_FirstFree );
-	::V_swap( m_pElements, that.m_pElements );
-	::V_swap( m_LastAlloc, that.m_LastAlloc );
+	V_swap( m_LessFunc, that.m_LessFunc );
+	V_swap( m_Root, that.m_Root );
+	V_swap( m_NumElements, that.m_NumElements );
+	V_swap( m_FirstFree, that.m_FirstFree );
+	V_swap( m_pElements, that.m_pElements );
+	V_swap( m_LastAlloc, that.m_LastAlloc );
 	Assert( IsValid() );
 	Assert( m_Elements.IsValidIterator( m_LastAlloc ) || ( m_NumElements == 0 && m_FirstFree == InvalidIndex() ) );
 }

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -1547,12 +1547,12 @@ template < class T, class I, typename L, class M >
 void CUtlRBTree<T, I, L, M>::Swap( CUtlRBTree< T, I, L > &that )
 {
 	m_Elements.Swap( that.m_Elements );
-	swap( m_LessFunc, that.m_LessFunc );
-	swap( m_Root, that.m_Root );
-	swap( m_NumElements, that.m_NumElements );
-	swap( m_FirstFree, that.m_FirstFree );
-	swap( m_pElements, that.m_pElements );
-	swap( m_LastAlloc, that.m_LastAlloc );
+	::V_swap( m_LessFunc, that.m_LessFunc );
+	::V_swap( m_Root, that.m_Root );
+	::V_swap( m_NumElements, that.m_NumElements );
+	::V_swap( m_FirstFree, that.m_FirstFree );
+	::V_swap( m_pElements, that.m_pElements );
+	::V_swap( m_LastAlloc, that.m_LastAlloc );
 	Assert( IsValid() );
 	Assert( m_Elements.IsValidIterator( m_LastAlloc ) || ( m_NumElements == 0 && m_FirstFree == InvalidIndex() ) );
 }

--- a/public/tier1/utlvector.h
+++ b/public/tier1/utlvector.h
@@ -415,7 +415,7 @@ void CUtlVector<T, A>::Sort( int (__cdecl *pfnCompare)(const T *, const T *) )
 			{
 				if ( pfnCompare( &Element( j - 1 ), &Element( j ) ) < 0 )
 				{
-					swap( Element( j - 1 ), Element( j ) );
+					::V_swap( Element( j - 1 ), Element( j ) );
 				}
 			}
 		}
@@ -605,8 +605,8 @@ template< typename T, class A >
 void CUtlVector<T, A>::Swap( CUtlVector< T, A > &vec )
 {
 	m_Memory.Swap( vec.m_Memory );
-	swap( m_Size, vec.m_Size );
-	swap( m_pElements, vec.m_pElements );
+	::V_swap( m_Size, vec.m_Size );
+	::V_swap( m_pElements, vec.m_pElements );
 }
 
 template< typename T, class A >

--- a/public/tier1/utlvector.h
+++ b/public/tier1/utlvector.h
@@ -415,7 +415,7 @@ void CUtlVector<T, A>::Sort( int (__cdecl *pfnCompare)(const T *, const T *) )
 			{
 				if ( pfnCompare( &Element( j - 1 ), &Element( j ) ) < 0 )
 				{
-					::V_swap( Element( j - 1 ), Element( j ) );
+					V_swap( Element( j - 1 ), Element( j ) );
 				}
 			}
 		}
@@ -605,8 +605,8 @@ template< typename T, class A >
 void CUtlVector<T, A>::Swap( CUtlVector< T, A > &vec )
 {
 	m_Memory.Swap( vec.m_Memory );
-	::V_swap( m_Size, vec.m_Size );
-	::V_swap( m_pElements, vec.m_pElements );
+	V_swap( m_Size, vec.m_Size );
+	V_swap( m_pElements, vec.m_pElements );
 }
 
 template< typename T, class A >

--- a/utils/common/mstristrip.cpp
+++ b/utils/common/mstristrip.cpp
@@ -365,7 +365,7 @@ STRIPLIST::iterator FindBestCachedStrip(STRIPLIST *pstriplist,
     // make sure we keep the list in order and always pull off
     // the first dude.
     if(istriplistbest != pstriplist->begin())
-        swap(*istriplistbest, *pstriplist->begin());
+        ::V_swap(*istriplistbest, *pstriplist->begin());
 
     return pstriplist->begin();
 }

--- a/utils/common/mstristrip.cpp
+++ b/utils/common/mstristrip.cpp
@@ -365,7 +365,7 @@ STRIPLIST::iterator FindBestCachedStrip(STRIPLIST *pstriplist,
     // make sure we keep the list in order and always pull off
     // the first dude.
     if(istriplistbest != pstriplist->begin())
-        ::V_swap(*istriplistbest, *pstriplist->begin());
+        V_swap(*istriplistbest, *pstriplist->begin());
 
     return pstriplist->begin();
 }

--- a/utils/vbsp/disp_ivp.cpp
+++ b/utils/vbsp/disp_ivp.cpp
@@ -207,7 +207,7 @@ CDispMeshEvent::CDispMeshEvent( unsigned short *pIndices, int indexCount, CCoreD
 	}
 	for ( int i = 0; i < indexCount/2; i++ )
 	{
-		::V_swap( pIndices[i], pIndices[(indexCount-i)-1] );
+		V_swap( pIndices[i], pIndices[(indexCount-i)-1] );
 	}
 	int count = maxIndex + 1;
 	m_verts.SetCount( count );

--- a/utils/vbsp/disp_ivp.cpp
+++ b/utils/vbsp/disp_ivp.cpp
@@ -207,7 +207,7 @@ CDispMeshEvent::CDispMeshEvent( unsigned short *pIndices, int indexCount, CCoreD
 	}
 	for ( int i = 0; i < indexCount/2; i++ )
 	{
-		swap( pIndices[i], pIndices[(indexCount-i)-1] );
+		::V_swap( pIndices[i], pIndices[(indexCount-i)-1] );
 	}
 	int count = maxIndex + 1;
 	m_verts.SetCount( count );


### PR DESCRIPTION
The `swap()` function provided in the MathLib header was renamed to `V_swap` in recent Source SDK versions (e.g. 2013) to avoid causing ambiguity problems with `std::swap()`. But older SDK versions (such as TF2) lack this change, as they predate it.

The ambiguity between MathLib's `swap()` and `std::swap()` causes considerable problems when using newer features of C++ (such as `std::unique_ptr`) which internally call `swap()` in an unqualified manner to implement move semantics:

```
/usr/include/c++/5.2.0/bits/unique_ptr.h:342:6: error: call of overloaded ‘swap(MyType*&, MyType*&)’ is ambiguous
/usr/include/c++/5.2.0/bits/move.h:176:5: note: candidate: void std::swap(_Tp&, _Tp&) [with _Tp = MyType*]
hl2sdk-tf2/public/mathlib/mathlib.h:611:18: note: candidate: void swap(T&, T&) [with T = MyType*]
```

This patch backports the `swap()` -> `V_swap()` rename from the 2013 SDK version to the TF2 SDK version, so that the TF2 SDK can be used in conjunction with C++11 features such as `std::unique_ptr` without difficulty.

More information on why `swap()` isn't called in a namespace-qualified manner by standard library functions:
http://en.cppreference.com/w/cpp/language/adl#Notes
