### PR TITLE
Fixed an include statement

### DIFF
--- a/public/avi/iavi.h
+++ b/public/avi/iavi.h
@@ -14,7 +14,7 @@
 #pragma once
 #endif
 
-#include "appframework/iappsystem.h"
+#include "appframework/IAppSystem.h"
 
 //-----------------------------------------------------------------------------
 // Forward declarations


### PR DESCRIPTION
The current include will cause a compiler error on Linux, because it's case-sensitive on directory/file names.

The Blade branch has the same problem.
