### PR TITLE
Updated MAX_EDICT_BITS constant

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -54,7 +54,7 @@
 #define SP_MODEL_INDEX_BITS			13
 
 // How many bits to use to encode an edict.
-#define	MAX_EDICT_BITS				11			// # of bits needed to represent max edicts
+#define	MAX_EDICT_BITS				12			// # of bits needed to represent max edicts
 // Max # of edicts in a level
 #define	MAX_EDICTS					(1<<MAX_EDICT_BITS)
 


### PR DESCRIPTION
It seems like MAX_EDICT_BITS has been increased with the last update. I have checked multiple functions/arrays where that value or a value that is based on MAX_EDICT_BITS is used.
