### PR TITLE
[gcc] fixed out of order initializers

### DIFF
--- a/public/bitmap/imageformat.h
+++ b/public/bitmap/imageformat.h
@@ -379,7 +379,7 @@ namespace ImageLoader
 	struct ResampleInfo_t
 	{
 
-		ResampleInfo_t() : m_nFlags(0), m_flAlphaThreshhold(0.4f), m_flAlphaHiFreqThreshhold(0.4f), m_nSrcDepth(1), m_nDestDepth(1)
+		ResampleInfo_t() : m_nSrcDepth(1), m_nDestDepth(1), m_flAlphaThreshhold(0.4f), m_flAlphaHiFreqThreshhold(0.4f), m_nFlags(0)
 		{
 			m_flColorScale[0] = 1.0f, m_flColorScale[1] = 1.0f, m_flColorScale[2] = 1.0f, m_flColorScale[3] = 1.0f;
 			m_flColorGoal[0] = 0.0f, m_flColorGoal[1] = 0.0f, m_flColorGoal[2] = 0.0f, m_flColorGoal[3] = 0.0f;

--- a/public/studio.h
+++ b/public/studio.h
@@ -2586,10 +2586,13 @@ public:
 
 		// ctor
 		CActivityToSequenceMapping( void ) 
-			: m_pSequenceTuples(NULL), m_iSequenceTuplesCount(0), m_ActToSeqHash(8,0,0), m_expectedPStudioHdr(NULL), m_expectedVModel(NULL) 
+			: m_pSequenceTuples(NULL), m_iSequenceTuplesCount(0),
 #if STUDIO_SEQUENCE_ACTIVITY_LAZY_INITIALIZE
-			, m_bIsInitialized(false) 
+			m_bIsInitialized(false),
 #endif
+			m_ActToSeqHash(8,0,0),
+			m_expectedPStudioHdr(NULL),
+			m_expectedVModel(NULL)
 		{};
 
 		// dtor -- not virtual because this class has no inheritors

--- a/public/tier0/vprof.h
+++ b/public/tier0/vprof.h
@@ -777,9 +777,9 @@ private:
 
 inline CVProfNode::CVProfNode( const tchar * pszName, int detailLevel, CVProfNode *pParent, const tchar *pBudgetGroupName, int budgetFlags )
  :	m_pszName( pszName ),
+	m_nRecursions( 0 ),
 	m_nCurFrameCalls( 0 ),
 	m_nPrevFrameCalls( 0 ),
-	m_nRecursions( 0 ),
 	m_pParent( pParent ),
 	m_pChild( NULL ),
 	m_pSibling( NULL ),

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -376,8 +376,8 @@ protected:
 
 template < class T, class I, typename L, class M >
 inline CUtlRBTree<T, I, L, M>::CUtlRBTree( int growSize, int initSize, const LessFunc_t &lessfunc ) : 
-m_Elements( growSize, initSize ),
 m_LessFunc( lessfunc ),
+m_Elements( growSize, initSize ),
 m_Root( InvalidIndex() ),
 m_NumElements( 0 ),
 m_FirstFree( InvalidIndex() ),
@@ -388,12 +388,12 @@ m_LastAlloc( m_Elements.InvalidIterator() )
 
 template < class T, class I, typename L, class M >
 inline CUtlRBTree<T, I, L, M>::CUtlRBTree( const LessFunc_t &lessfunc ) : 
-m_Elements( 0, 0 ),
 m_LessFunc( lessfunc ),
+m_Elements( 0, 0 ),
 m_Root( InvalidIndex() ),
 m_NumElements( 0 ),
-m_FirstFree( InvalidIndex() ),
-m_LastAlloc( m_Elements.InvalidIterator() )
+m_LastAlloc( m_Elements.InvalidIterator() ),
+m_FirstFree( InvalidIndex() )
 {
 	ResetDbgInfo();
 }


### PR DESCRIPTION
SourceMod fails to build under Debian 8  on GCC 4.9.2 due to out of order initializes due to the `-Werror=reorder ` option being set. This patch corrects this issue by fixing the initialization order.