### PR TITLE
Hacky fix for SM issue 666

### DIFF
--- a/public/tier0/dbg.h
+++ b/public/tier0/dbg.h
@@ -222,7 +222,7 @@ DBG_INTERFACE void SetAssertFailedNotifyFunc( AssertFailedNotifyFunc_t func );
 DBG_INTERFACE void CallAssertFailedNotifyFunc( const char *pchFile, int nLine, const char *pchMessage );
 
 /* True if -hushasserts was passed on command line. */
-DBG_INTERFACE bool HushAsserts();
+//DBG_INTERFACE bool HushAsserts();
 
 #if defined( USE_SDL )
 DBG_INTERFACE void SetAssertDialogParent( struct SDL_Window *window );

--- a/public/tier0/dbg.h
+++ b/public/tier0/dbg.h
@@ -222,7 +222,7 @@ DBG_INTERFACE void SetAssertFailedNotifyFunc( AssertFailedNotifyFunc_t func );
 DBG_INTERFACE void CallAssertFailedNotifyFunc( const char *pchFile, int nLine, const char *pchMessage );
 
 /* True if -hushasserts was passed on command line. */
-//DBG_INTERFACE bool HushAsserts();
+DBG_INTERFACE bool HushAsserts();
 
 #if defined( USE_SDL )
 DBG_INTERFACE void SetAssertDialogParent( struct SDL_Window *window );


### PR DESCRIPTION
https://github.com/alliedmodders/sourcemod/issues/666

The tier1 lib will need to be recompiled for all platforms as well.

Calls to the new functions in mods on older versions of the SDK obviously causes crashes,
and the interface isn't versioned. Use the existence of an exported function in the associated tier0
that was introduced at the same time as these as a psuedo version check.