### PR TITLE
Fixed classes for latest csgo update 30/03/2018

### DIFF
--- a/public/datacache/imdlcache.h
+++ b/public/datacache/imdlcache.h
@@ -132,6 +132,7 @@ public:
 	// Gets at the various data associated with a MDL
 	virtual studiohdr_t *GetStudioHdr( MDLHandle_t handle ) = 0;
 	virtual studiohwdata_t *GetHardwareData( MDLHandle_t handle ) = 0;
+	virtual vcollide_t *GetVCollideScaled( MDLHandle_t handle, float flScale ) = 0;
 	virtual vcollide_t *GetVCollide( MDLHandle_t handle ) = 0;
 	virtual unsigned char *GetAnimBlock( MDLHandle_t handle, int nBlock ) = 0;
 

--- a/public/datacache/imdlcache.h
+++ b/public/datacache/imdlcache.h
@@ -133,6 +133,7 @@ public:
 	virtual studiohdr_t *GetStudioHdr( MDLHandle_t handle ) = 0;
 	virtual studiohwdata_t *GetHardwareData( MDLHandle_t handle ) = 0;
 	virtual vcollide_t *GetVCollide( MDLHandle_t handle ) = 0;
+	virtual vcollide_t *GetVCollide( MDLHandle_t handle, float flScale ) = 0;
 	virtual unsigned char *GetAnimBlock( MDLHandle_t handle, int nBlock ) = 0;
 
 	virtual bool HasAnimBlockBeenPreloaded( MDLHandle_t handle, int iAnim) = 0;

--- a/public/datacache/imdlcache.h
+++ b/public/datacache/imdlcache.h
@@ -132,7 +132,6 @@ public:
 	// Gets at the various data associated with a MDL
 	virtual studiohdr_t *GetStudioHdr( MDLHandle_t handle ) = 0;
 	virtual studiohwdata_t *GetHardwareData( MDLHandle_t handle ) = 0;
-	virtual vcollide_t *GetVCollideScaled( MDLHandle_t handle, float flScale ) = 0;
 	virtual vcollide_t *GetVCollide( MDLHandle_t handle ) = 0;
 	virtual unsigned char *GetAnimBlock( MDLHandle_t handle, int nBlock ) = 0;
 

--- a/public/engine/ivmodelinfo.h
+++ b/public/engine/ivmodelinfo.h
@@ -65,10 +65,8 @@ public:
 
 	// Returns name of model
 	virtual const char				*GetModelName( const model_t *model ) const = 0;
-	virtual vcollide_t				*GetVCollideScaled( int modelindex, float flScale ) const = 0;
-	virtual vcollide_t				*GetVCollideScaled( const model_t *model, float flScale ) const = 0;
-	virtual vcollide_t				*GetVCollide( int modelindex ) const = 0;
 	virtual vcollide_t				*GetVCollide( const model_t *model ) const = 0;
+	virtual vcollide_t				*GetVCollide( int modelindex ) const = 0;
 	virtual void					GetModelBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual	void					GetModelRenderBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual int						GetModelFrameCount( const model_t *model ) const = 0;

--- a/public/engine/ivmodelinfo.h
+++ b/public/engine/ivmodelinfo.h
@@ -67,6 +67,8 @@ public:
 	virtual const char				*GetModelName( const model_t *model ) const = 0;
 	virtual vcollide_t				*GetVCollide( const model_t *model ) const = 0;
 	virtual vcollide_t				*GetVCollide( int modelindex ) const = 0;
+	virtual vcollide_t				*GetVCollide( const model_t *model, float flScale ) const = 0;
+	virtual vcollide_t				*GetVCollide( int modelindex, float flScale ) const = 0;
 	virtual void					GetModelBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual	void					GetModelRenderBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual int						GetModelFrameCount( const model_t *model ) const = 0;

--- a/public/engine/ivmodelinfo.h
+++ b/public/engine/ivmodelinfo.h
@@ -65,8 +65,10 @@ public:
 
 	// Returns name of model
 	virtual const char				*GetModelName( const model_t *model ) const = 0;
-	virtual vcollide_t				*GetVCollide( const model_t *model ) const = 0;
+	virtual vcollide_t				*GetVCollideScaled( int modelindex, float flScale ) const = 0;
+	virtual vcollide_t				*GetVCollideScaled( const model_t *model, float flScale ) const = 0;
 	virtual vcollide_t				*GetVCollide( int modelindex ) const = 0;
+	virtual vcollide_t				*GetVCollide( const model_t *model ) const = 0;
 	virtual void					GetModelBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual	void					GetModelRenderBounds( const model_t *model, Vector& mins, Vector& maxs ) const = 0;
 	virtual int						GetModelFrameCount( const model_t *model ) const = 0;


### PR DESCRIPTION
Valve added static prop scaling and therefore they added new virtual functiongs to get the VCollide with a scale.