### PR TITLE
tf2: Fix IsPowerOfTwo clash in memalloc

### DIFF
--- a/public/tier0/memalloc.h
+++ b/public/tier0/memalloc.h
@@ -178,7 +178,7 @@ inline void *MemAlloc_AllocAligned( size_t size, size_t align )
 {
 	unsigned char *pAlloc, *pResult;
 
-	if (!IsPowerOfTwo(align))
+	if (!ValueIsPowerOfTwo(align))
 		return NULL;
 
 	align = (align > sizeof(void *) ? align : sizeof(void *)) - 1;
@@ -196,7 +196,7 @@ inline void *MemAlloc_AllocAligned( size_t size, size_t align, const char *pszFi
 {
 	unsigned char *pAlloc, *pResult;
 
-	if (!IsPowerOfTwo(align))
+	if (!ValueIsPowerOfTwo(align))
 		return NULL;
 
 	align = (align > sizeof(void *) ? align : sizeof(void *)) - 1;
@@ -248,7 +248,7 @@ inline void *MemAlloc_AllocAlignedFileLine( size_t size, size_t align, const cha
 
 inline void *MemAlloc_ReallocAligned( void *ptr, size_t size, size_t align )
 {
-	if ( !IsPowerOfTwo( align ) )
+	if ( !ValueIsPowerOfTwo( align ) )
 		return NULL;
 
 	// Don't change alignment between allocation + reallocation.


### PR DESCRIPTION
Fix part of #50. Same as PR #54 but for a different SDK.

Given that
```
inline bool ValueIsPowerOfTwo( size_t value ) // don't clash with mathlib definition
```
already exists, it is safe to assume that it was meant to be used in all the cases where `IsPowerOfTwo` is used with a `size_t` argument to avoid the clash with `mathlib` and `commonmacros`.

**It seems like this issue might be common to all the SDK versions!**