### PR TITLE
sdk2013: Mac: fix debug build warning from DebuggerBreak

### DIFF
--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -427,7 +427,7 @@ typedef void * HINSTANCE;
 	// On OSX, SIGTRAP doesn't really stop the thread cold when debugging.
 	// So if being debugged, use INT3 which is precise.
 #ifdef OSX
-#define DebuggerBreak()  if ( Plat_IsInDebugSession() ) { __asm ( "int $3" ); } else { raise(SIGTRAP); }
+#define DebuggerBreak()  do { if ( Plat_IsInDebugSession() ) { __asm ( "int $3" ); } else { raise(SIGTRAP); } } while (0)
 #else
 #define DebuggerBreak()  raise(SIGTRAP)
 #endif


### PR DESCRIPTION
Fix #52

Wrap the macro in `do { ... } while (0)` to avoid dangling `else`s when it is used in if statements