### PR TITLE
sdk2013: Fix memdbg on Mac

### DIFF
--- a/public/tier0/memdbgon.h
+++ b/public/tier0/memdbgon.h
@@ -33,7 +33,11 @@
 #include <wchar.h>
 #endif
 #include <string.h>
+#if defined __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include "commonmacros.h"
 #include "memalloc.h"
 

--- a/public/tier1/utlstring.h
+++ b/public/tier1/utlstring.h
@@ -16,6 +16,8 @@
 #include "limits.h"
 
 #if defined( OSX )
+
+#if !defined( wcsdup )
 inline wchar_t *wcsdup(const wchar_t *pString)
 {
 	wchar_t *pMemory;
@@ -31,6 +33,7 @@ inline wchar_t *wcsdup(const wchar_t *pString)
 
 	return NULL;
 }
+#endif
 
 inline size_t strnlen(const char *s, size_t n)
 {


### PR DESCRIPTION
Fix #55.

Implements the suggested fixes:
1. Include `<stdlib.h>` isntead of `<malloc.h>` on Mac, just as in `platform.h`
1. Stop `utlstring.h` from providing its version of `wcsdup` when `memdbgon.h` has been included.