### PR TITLE
sdk2013: Mac: debug: fix compilation with -Werror

### DIFF
--- a/public/tier0/dbg.h
+++ b/public/tier0/dbg.h
@@ -567,7 +567,7 @@ public:
 // of our complicated templates properly.  Use some preprocessor trickery
 // to workaround this
 #ifdef __GNUC__
-	#define COMPILE_TIME_ASSERT( pred ) typedef int UNIQUE_ID[ (pred) ? 1 : -1 ]
+	#define COMPILE_TIME_ASSERT( pred ) typedef int UNIQUE_ID[ (pred) ? 1 : -1 ] __attribute__((unused))
 #else
 	#if _MSC_VER >= 1600
 	// If available use static_assert instead of weird language tricks. This

--- a/public/tier0/dbg.h
+++ b/public/tier0/dbg.h
@@ -566,7 +566,15 @@ public:
 // We're using an ancient version of GCC that can't quite handle some
 // of our complicated templates properly.  Use some preprocessor trickery
 // to workaround this
-#ifdef __GNUC__
+#ifndef __has_feature
+  #define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+#if __has_feature(cxx_static_assert)
+	// If available use static_assert instead of weird language tricks. This
+	// leads to much more readable messages when compile time assert constraints
+	// are violated.
+	#define COMPILE_TIME_ASSERT( pred ) static_assert( pred, "Compile time assert constraint is not true: " #pred )
+#elif defined __GNUC__
 	#define COMPILE_TIME_ASSERT( pred ) typedef int UNIQUE_ID[ (pred) ? 1 : -1 ] __attribute__((unused))
 #else
 	#if _MSC_VER >= 1600

--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -427,7 +427,7 @@ typedef void * HINSTANCE;
 	// On OSX, SIGTRAP doesn't really stop the thread cold when debugging.
 	// So if being debugged, use INT3 which is precise.
 #ifdef OSX
-#define DebuggerBreak()  if ( Plat_IsInDebugSession() ) { __asm ( "int $3" ); } else { raise(SIGTRAP); }
+#define DebuggerBreak()  do { if ( Plat_IsInDebugSession() ) { __asm ( "int $3" ); } else { raise(SIGTRAP); } } while (0)
 #else
 #define DebuggerBreak()  raise(SIGTRAP)
 #endif

--- a/public/tier1/utlblockmemory.h
+++ b/public/tier1/utlblockmemory.h
@@ -337,7 +337,6 @@ void CUtlBlockMemory<T,I>::Purge( int numElements )
 	}
 
 	int nBlockSize = NumElementsInBlock();
-	int nBlocksOld = m_nBlocks;
 	int nBlocks = ( numElements + nBlockSize - 1 ) / nBlockSize;
 
 	// If the number of blocks is the same as the allocated number of blocks, we are done.


### PR DESCRIPTION
Fix #52 

Implements the suggested fixes AND makes `COMPILE_TIME_ASSERT` use `static_assert` on clang, just as it does on modern MSVC.