### PR TITLE
Update ICvar::RegisterConCommand params

### DIFF
--- a/public/icvar.h
+++ b/public/icvar.h
@@ -62,7 +62,7 @@ public:
 	virtual CVarDLLIdentifier_t AllocateDLLIdentifier() = 0;
 
 	// Register, unregister commands
-	virtual void			RegisterConCommand( ConCommandBase *pCommandBase ) = 0;
+	virtual void			RegisterConCommand( ConCommandBase *pCommandBase, bool unknown=true ) = 0;
 	virtual void			UnregisterConCommand( ConCommandBase *pCommandBase ) = 0;
 	virtual void			UnregisterConCommands( CVarDLLIdentifier_t id ) = 0;
 


### PR DESCRIPTION
Latest CS:GO update added new param to RegisterConCommand function.
Linux still working only because use __cdecl as default call convention. Crash on windows with stack corruption.
Function reverse show this:
```
{
	...
	// esi ConCommandBase *variable
	// eax variable->vftable
	if (unknown)
	{
		if (variable->vftable->vfunc4(variable) == false) // vfunc 0x04
		{
			if (variable->vftable->vfunc8(variable, 2) == false) // vfunc 0x08
			{
				int v1 = sub_10003330(variable->vftable->vfunc18(variable)); // vfunc 0x18 // sub_10003330 = vfunc 0x34
				if (v1)
				{
					void *v2 = variable + 0x18;
					v2->vftable->vfuncC(v2, v1); // vfunc 0x0C
				}
			}
		}
	}
}
```
My guess:
```
{
	...
	// ConCommandBase *variable
	// bool unknown
	if (unknown)
	{
		if (!variable->IsCommand())
		{
			if (!variable->IsFlagSet(FCVAR_DEVELOPMENTONLY))
			{
				const char *v1 = GetCommandLineValue(variable->GetName());
				if (v1)
				{
					ConVar *cvar = (ConVar*)variable;
					cvar->SetValue(v1);
				}
			}
		}
	}
}
```
I checked CGameDLL_ConVarAccessor::RegisterConCommandBase in game.dll, for value passed by default for RegisterConCommand - it is "true".
https://github.com/VSES/SourceEngine2007/blob/master/src_main/game/server/game.cpp#L56
```
bool __thiscall sub_102818F0(int this, _DWORD *pCommand)
{
  int v3; // ebx
  int v4; // esi
  int v5; // eax
  char v7; // [esp+13h] [ebp+Bh]

  v3 = 0;
  v7 = (*(int (__thiscall **)(_DWORD *, signed int))(*pCommand + 8))(pCommand, 0x2000);
  if ( v7 && !(*(unsigned __int8 (__thiscall **)(_DWORD *))(*pCommand + 4))(pCommand) )
    v3 = *(_DWORD *)(pCommand[7] + 32);
  (*(void (__stdcall **)(_DWORD *, signed int))(*(_DWORD *)dword_10AF3A68 + 40))(pCommand, 1);
  if ( v7 )
  {
    if ( v3 )
    {
      if ( !(*(unsigned __int8 (__thiscall **)(_DWORD *))(*pCommand + 4))(pCommand) )
      {
        v4 = *(_DWORD *)dword_10AF3A68;
        v5 = (*(int (__thiscall **)(_DWORD *))(*pCommand + 24))(pCommand);
        if ( !(*(unsigned __int8 (__thiscall **)(int, int))(v4 + 52))(dword_10AF3A68, v5) )
          (*(void (__thiscall **)(_DWORD *, int))(pCommand[6] + 12))(pCommand + 6, v3);
      }
    }
  }
  return 1;
}
```
Changes compiled and tested successful.