### PR TITLE
csgo: Update ICvar interface

### DIFF
--- a/public/icvar.h
+++ b/public/icvar.h
@@ -62,13 +62,11 @@ public:
 	virtual CVarDLLIdentifier_t AllocateDLLIdentifier() = 0;
 
 	// Register, unregister commands
-	virtual void			RegisterConCommand( ConCommandBase *pCommandBase, bool unknown=true ) = 0;
+	virtual void			RegisterConCommand( ConCommandBase *pCommandBase, bool cmdline=true ) = 0;
 	virtual void			UnregisterConCommand( ConCommandBase *pCommandBase ) = 0;
 	virtual void			UnregisterConCommands( CVarDLLIdentifier_t id ) = 0;
 
-	// If there is a +<varname> <value> on the command line, this returns the value.
-	// Otherwise, it returns NULL.
-	virtual const char*		GetCommandLineValue( const char *pVariableName ) = 0;
+	virtual bool			HasCommandLineValue( const char *pVariableName ) = 0;
 
 	// Try to find the cvar pointer by name
 	virtual ConCommandBase *FindCommandBase( const char *name ) = 0;

--- a/public/icvar.h
+++ b/public/icvar.h
@@ -66,6 +66,9 @@ public:
 	virtual void			UnregisterConCommand( ConCommandBase *pCommandBase ) = 0;
 	virtual void			UnregisterConCommands( CVarDLLIdentifier_t id ) = 0;
 
+	// If there is a +<varname> <value> on the command line, this returns the value.
+	// Otherwise, it returns NULL.
+	inline static const char *GetCommandLineValue( const char *pVariableName );
 	virtual bool			HasCommandLineValue( const char *pVariableName ) = 0;
 
 	// Try to find the cvar pointer by name
@@ -193,6 +196,19 @@ inline bool ICvar::Iterator::IsValid( void )
 inline ConCommandBase * ICvar::Iterator::Get( void )
 {
 	return m_pIter->Get();
+}
+
+inline const char *ICvar::GetCommandLineValue( const char *pVariableName )
+{
+	if (pVariableName[0] == '\0')
+		return NULL;
+	size_t len = strlen(pVariableName);
+	char *search = new char[len + 2];
+	search[0] = '+';
+	memcpy(&search[1], pVariableName, len + 1);
+	const char *value = CommandLine()->ParmValue(search);
+	delete[] search;
+	return value;
 }
 
 

--- a/public/icvar.h
+++ b/public/icvar.h
@@ -68,7 +68,7 @@ public:
 
 	// If there is a +<varname> <value> on the command line, this returns the value.
 	// Otherwise, it returns NULL.
-	inline static const char *GetCommandLineValue( const char *pVariableName );
+	inline const char*		GetCommandLineValue( const char *pVariableName );
 	virtual bool			HasCommandLineValue( const char *pVariableName ) = 0;
 
 	// Try to find the cvar pointer by name


### PR DESCRIPTION
GetCommandLineValue was replaced by HasCommandLineValue.
Update RegisterConCommand param name.

This changes must be added only together with MM:S and SM PRs (WIP).
100% sure that GetCommandLineValue was replaced and not available as interface anymore.
This update is reason of bug with MM:S and SM command line basepath values.