### PR TITLE
Fix compilation errors on GCC8+ 

### DIFF
--- a/public/tier1/utlmemory.h
+++ b/public/tier1/utlmemory.h
@@ -20,6 +20,7 @@
 
 #include "tier0/memalloc.h"
 #include "tier0/memdbgon.h"
+#include "mathlib/math_base.h"
 
 #ifdef _MSC_VER
 #pragma warning (disable:4100)


### PR DESCRIPTION
Not sure if this is breaking ABI, I don't believe so. Once this is merged, we'll be able to gracefully continue with alliedmodders/sourcemod#1054

Paired with #64 