### PR TITLE
Fix error: ‘max’ was not declared in this scope

### DIFF
--- a/tier1/KeyValues.cpp
+++ b/tier1/KeyValues.cpp
@@ -79,7 +79,7 @@ public:
 			m_errorStack[m_errorIndex] = symName;
 		}
 		m_errorIndex++;
-		m_maxErrorIndex = max( m_maxErrorIndex, (m_errorIndex-1) );
+		m_maxErrorIndex = MAX( m_maxErrorIndex, (m_errorIndex-1) );
 		return m_errorIndex-1;
 	}
 


### PR DESCRIPTION
Wasn't sure whether or not I should use the new ``V_max``, so I decided to use what the other branches use as well.