### PR TITLE
Update CSGO's GetTickInterval and tickrate related constants

### DIFF
--- a/game/server/gameinterface.cpp
+++ b/game/server/gameinterface.cpp
@@ -925,17 +925,25 @@ void CServerGameDLL::DLLShutdown( void )
 //-----------------------------------------------------------------------------
 float CServerGameDLL::GetTickInterval( void ) const
 {
-	float tickinterval = DEFAULT_TICK_INTERVAL;
-
-
-
+	float tickinterval = 1.0 / 29.97; // 0.03336666
+	if ( !engine->IsDedicatedServerForXbox() )
+	{
+		tickinterval = 1.0 / 30.0; // 0.03333333
+		if ( !engine->IsDedicatedServerForPS3() )
+		{
+			tickinterval = DEFAULT_TICK_INTERVAL;
+		}
+	}
 
 	// override if tick rate specified in command line
 	if ( CommandLine()->CheckParm( "-tickrate" ) )
 	{
 		float tickrate = CommandLine()->ParmValue( "-tickrate", 0 );
-		if ( tickrate > 10 )
-			tickinterval = 1.0f / tickrate;
+		if ( tickrate > 0 )
+		{
+			tickinterval = floorf((1.0f / tickrate) * 512.0 + 0.5) / 512.0;
+		}
+		tickinterval = clamp(tickinterval, MINIMUM_TICK_INTERVAL, MAXIMUM_TICK_INTERVAL);
 	}
 
 

--- a/public/const.h
+++ b/public/const.h
@@ -1,4 +1,4 @@
-//========= Copyright � 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //

--- a/public/const.h
+++ b/public/const.h
@@ -26,7 +26,7 @@
 
 // This is the default, see shareddefs.h for mod-specific value, which can override this
 #define DEFAULT_TICK_INTERVAL	(1.0f / 64.0f)	// 0.015625
-#define MINIMUM_TICK_INTERVAL   (1.0f / 128.0f) // 0.0078125
+#define MINIMUM_TICK_INTERVAL	(1.0f / 128.0f) // 0.0078125
 #define MAXIMUM_TICK_INTERVAL	(1.0f / 20.48f)	// 0.048828125
 
 // This is the max # of players the engine can handle

--- a/public/const.h
+++ b/public/const.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright ï¿½ 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //
@@ -25,9 +25,9 @@
 #define INVALID_STEAM_LOGGED_IN_ELSEWHERE "This Steam account is being used in another location\n"
 
 // This is the default, see shareddefs.h for mod-specific value, which can override this
-#define DEFAULT_TICK_INTERVAL	(1.0f / 60.0f)				// 16.666667 msec is the default
-#define MINIMUM_TICK_INTERVAL   (0.001)
-#define MAXIMUM_TICK_INTERVAL	(0.1)
+#define DEFAULT_TICK_INTERVAL	(1.0f / 64.0f)	// 0.015625
+#define MINIMUM_TICK_INTERVAL   (1.0f / 128.0f) // 0.0078125
+#define MAXIMUM_TICK_INTERVAL	(1.0f / 20.48f)	// 0.048828125
 
 // This is the max # of players the engine can handle
 // Note, must be power of 2


### PR DESCRIPTION
By doing a bindiff between the 2016 linux binary and the current one, this is `CServerGameDLL::GetTickInterval( void )`:
```c++
long double sub_6BA2F0()
{
  float v0; // xmm0_4
  int v1; // eax
  int v2; // eax
  float v5; // [esp+1Ch] [ebp-3Ch]
  float v6; // [esp+1Ch] [ebp-3Ch]

  v0 = 0.033366665;
  if ( !(*(unsigned __int8 (__cdecl **)(int))(*(_DWORD *)dword_174458C + 492))(dword_174458C) )
  {
    v0 = 0.033333335;
    if ( !(*(unsigned __int8 (__cdecl **)(int))(*(_DWORD *)dword_174458C + 496))(dword_174458C) )
      v0 = 0.015625;
  }
  v1 = CommandLine();
  if ( (*(int (__cdecl **)(int, const char *, _DWORD))(*(_DWORD *)v1 + 12))(v1, "-tickrate", 0) )
  {
    v2 = CommandLine();
    v5 = ((long double (__cdecl *)(int, const char *, _DWORD))*(_DWORD *)(*(_DWORD *)v2 + 36))(v2, "-tickrate", 0);
    if ( v5 > 0.0 )
    {
      _FST7 = (float)((float)((float)(1.0 / v5) * 512.0) + 0.5);
      __asm { frndint }
      v6 = _FST7;
      v0 = v6 * 0.001953125;
    }
    v0 = fmaxf(fminf(v0, 0.048828125), 0.0078125);
  }
  return v0;
}
```

`dword_174458C` is engine, the related pseudocode is as below:
```c++
    COM_TimestampedLog("Factories - Start");
    v6 = a2("VEngineServer023", 0);
    dword_174458C = v6;    
```
This seems to match with the following code in gameinterface.cpp in the SDK:
```c++
	COM_TimestampedLog( "Factories - Start" );

	// init each (seperated for ease of debugging)
	if ( (engine = (IVEngineServer*)appSystemFactory(INTERFACEVERSION_VENGINESERVER, NULL)) == NULL )
		return false;
```
By following the offsets of IVEngineServer in eiface.h, the two functions called are `IsDedicatedServerForXbox()` and `IsDedicatedServerForPS3()` (actually with offset by 1, most likely because eiface.h is slightly out of date and another function got removed somewhere above)