### PR TITLE
Fix "declaration of swap must be available"

### DIFF
--- a/public/tier1/utlblockmemory.h
+++ b/public/tier1/utlblockmemory.h
@@ -137,10 +137,10 @@ CUtlBlockMemory<T,I>::~CUtlBlockMemory()
 template< class T, class I >
 void CUtlBlockMemory<T,I>::Swap( CUtlBlockMemory< T, I > &mem )
 {
-	swap( m_pMemory, mem.m_pMemory );
-	swap( m_nBlocks, mem.m_nBlocks );
-	swap( m_nIndexMask, mem.m_nIndexMask );
-	swap( m_nIndexShift, mem.m_nIndexShift );
+	V_swap( m_pMemory, mem.m_pMemory );
+	V_swap( m_nBlocks, mem.m_nBlocks );
+	V_swap( m_nIndexMask, mem.m_nIndexMask );
+	V_swap( m_nIndexShift, mem.m_nIndexShift );
 }
 
 


### PR DESCRIPTION
Fixes
```
../hl2sdk-sdk2013/public/tier1/utlblockmemory.h:141:2: warning: there are no arguments to ‘swap’ that
depend on a template parameter, so a declaration of ‘swap’ must be available [-fpermissive]
  141 |  swap( m_nBlocks, mem.m_nBlocks );
      |  ^~~~
```