### PR TITLE
fix conflicting return type

### DIFF
--- a/game/shared/gamemovement.h
+++ b/game/shared/gamemovement.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//========= Copyright Â© 1996-2005, Valve Corporation, All rights reserved. ============//
 //
 // Purpose: 
 //
@@ -105,8 +105,8 @@ protected:
 	// Implement this if you want to know when the player collides during OnPlayerMove
 	virtual void	OnTryPlayerMoveCollision( trace_t &tr ) {}
 
-	virtual const Vector&	GetPlayerMins( void ) const; // uses local player
-	virtual const Vector&	GetPlayerMaxs( void ) const; // uses local player
+	virtual Vector	GetPlayerMins( void ) const; // uses local player
+	virtual Vector	GetPlayerMaxs( void ) const; // uses local player
 
 	typedef enum
 	{

--- a/game/shared/gamemovement.h
+++ b/game/shared/gamemovement.h
@@ -42,9 +42,9 @@ public:
 	virtual void	StartTrackPredictionErrors( CBasePlayer *pPlayer );
 	virtual void	FinishTrackPredictionErrors( CBasePlayer *pPlayer );
 	virtual void	DiffPrint( char const *fmt, ... );
-	virtual const Vector&	GetPlayerMins( bool ducked ) const;
-	virtual const Vector&	GetPlayerMaxs( bool ducked ) const;
-	virtual const Vector&	GetPlayerViewOffset( bool ducked ) const;
+	virtual Vector  GetPlayerMins( bool ducked ) const;
+	virtual Vector	GetPlayerMaxs( bool ducked ) const;
+	virtual Vector	GetPlayerViewOffset( bool ducked ) const;
 
 // For sanity checking getting stuck on CMoveData::SetAbsOrigin
 	virtual void			TracePlayerBBox( const Vector& start, const Vector& end, unsigned int fMask, int collisionGroup, trace_t& pm );


### PR DESCRIPTION
Example bad compile:
```c
[  6%] Building CXX object CMakeFiles/TFTrue.dir/AutoUpdater.cpp.o
In file included from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:45:24: error: conflicting return type specified for ‘virtual const Vector& CGameMovement::GetPlayerMins(bool) const’
   45 |  virtual const Vector& GetPlayerMins( bool ducked ) const;
      |                        ^~~~~~~~~~~~~
In file included from /home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:15,
                 from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/igamemovement.h:122:17: note: overridden function is ‘virtual Vector IGameMovement::GetPlayerMins(bool) const’
  122 |  virtual Vector GetPlayerMins( bool ducked ) const = 0;
      |                 ^~~~~~~~~~~~~
In file included from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:46:24: error: conflicting return type specified for ‘virtual const Vector& CGameMovement::GetPlayerMaxs(bool) const’
   46 |  virtual const Vector& GetPlayerMaxs( bool ducked ) const;
      |                        ^~~~~~~~~~~~~
In file included from /home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:15,
                 from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/igamemovement.h:123:17: note: overridden function is ‘virtual Vector IGameMovement::GetPlayerMaxs(bool) const’
  123 |  virtual Vector GetPlayerMaxs( bool ducked ) const = 0;
      |                 ^~~~~~~~~~~~~
In file included from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:47:24: error: conflicting return type specified for ‘virtual const Vector& CGameMovement::GetPlayerViewOffset(bool) const’
   47 |  virtual const Vector& GetPlayerViewOffset( bool ducked ) const;
      |                        ^~~~~~~~~~~~~~~~~~~
In file included from /home/steph/TFTrue/hl2sdk-tf2/game/shared/gamemovement.h:15,
                 from /home/steph/TFTrue/SDK.h:38,
                 from /home/steph/TFTrue/AutoUpdater.h:27,
                 from /home/steph/TFTrue/AutoUpdater.cpp:19:
/home/steph/TFTrue/hl2sdk-tf2/game/shared/igamemovement.h:124:18: note: overridden function is ‘virtual Vector IGameMovement::GetPlayerViewOffset(bool) const’
  124 |  virtual Vector  GetPlayerViewOffset( bool ducked ) const = 0;
      |                  ^~~~~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/TFTrue.dir/build.make:82: CMakeFiles/TFTrue.dir/AutoUpdater.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/TFTrue.dir/all] Error 2
gmake: *** [Makefile:103: all] Error 2
```

This should've been updated when this was updated:

https://github.com/alliedmodders/hl2sdk/commit/5ad032f3502aa2590244f3610e29d045c713f588