### PR TITLE
SDK2013: Fix even more build errors caused by c33f715: mathlib

### DIFF
--- a/mathlib/imagequant.cpp
+++ b/mathlib/imagequant.cpp
@@ -46,7 +46,7 @@ void ColorQuantize(uint8 const *Image,
 					val1+=PIXEL(x,y,c)*ExtraValueXForms[i*3+c];
 				val1>>=8;
 				NthSample(s,y*Width+x,N_DIMENSIONS)->Value[c]=(uint8)
-					(min(255,max(0,val1)));
+					(V_min(255,V_max(0,val1)));
 			}
 		}
 	struct QuantizedValue *q=Quantize(s,Width*Height,N_DIMENSIONS,
@@ -76,7 +76,7 @@ void ColorQuantize(uint8 const *Image,
 					tryc+=Error[x][c][ErrorUse];
 					Error[x][c][ErrorUse]=0;
 				}
-				samp[c]=(uint8) min(255,max(0,tryc));
+				samp[c]=(uint8) V_min(255,V_max(0,tryc));
 			}
 			struct QuantizedValue *f=FindMatch(samp,3,Weights,q);
 			out_pixels[Width*y+x]=(uint8) (f->value);

--- a/mathlib/mathlib_base.cpp
+++ b/mathlib/mathlib_base.cpp
@@ -1777,7 +1777,7 @@ void QuaternionScale( const Quaternion &p, float t, Quaternion &q )
 	// FIXME: nick, this isn't overly sensitive to accuracy, and it may be faster to 
 	// use the cos part (w) of the quaternion (sin(omega)*N,cos(omega)) to figure the new scale.
 	float sinom = sqrt( DotProduct( &p.x, &p.x ) );
-	sinom = min( sinom, 1.f );
+	sinom = V_min( sinom, 1.f );
 
 	float sinsom = sin( asin( sinom ) * t );
 
@@ -4057,10 +4057,10 @@ void CalcTriangleTangentSpace( const Vector &p0, const Vector &p1, const Vector 
 //-----------------------------------------------------------------------------
 void RGBtoHSV( const Vector &rgb, Vector &hsv )
 {
-	float flMax = max( rgb.x, rgb.y );
-	flMax = max( flMax, rgb.z );
-	float flMin = min( rgb.x, rgb.y );
-	flMin = min( flMin, rgb.z );
+	float flMax = V_max( rgb.x, rgb.y );
+	flMax = V_max( flMax, rgb.z );
+	float flMin = V_min( rgb.x, rgb.y );
+	flMin = V_min( flMin, rgb.z );
 
 	// hsv.z is the value
 	hsv.z = flMax;

--- a/mathlib/quantize.cpp
+++ b/mathlib/quantize.cpp
@@ -411,8 +411,8 @@ static void Label(struct QuantizedValue *q, int updatecolor)
 		else
 			for(int i=0;i<current_ndims;i++)
 			{
-				q->Mins[i]=min(q->Children[0]->Mins[i],q->Children[1]->Mins[i]);
-				q->Maxs[i]=max(q->Children[0]->Maxs[i],q->Children[1]->Maxs[i]);
+				q->Mins[i]=V_min(q->Children[0]->Mins[i],q->Children[1]->Mins[i]);
+				q->Maxs[i]=V_max(q->Children[0]->Maxs[i],q->Children[1]->Maxs[i]);
 			}
 	}
 }    

--- a/mathlib/simdvectormatrix.cpp
+++ b/mathlib/simdvectormatrix.cpp
@@ -48,7 +48,7 @@ void CSIMDVectorMatrix::CreateFromRGBA_FloatImageData(int srcwidth, int srcheigh
 			{
 				for(int cp=0;cp<4; cp++)
 				{
-					int real_cp=min( cp, ntrailing_pixels_per_source_line-1 );
+					int real_cp=V_min( cp, ntrailing_pixels_per_source_line-1 );
 					data_out[4*c+cp]= data_in[c+4*real_cp];
 				}
 			}


### PR DESCRIPTION
Attempting to build stuff other than tier1 is broken because when the `V_min` and `V_max` macros were (appropriately) renamed, nobody really bothered to make sure that all the references were actually updated accordingly.

The tier1 build seems to have been fixed by #94. But mathlib is still busted. This PR fixes mathlib. (Or, in any case, it was the minimal number of edits I needed for the build I was doing to work.)

This PR doesn't attempt to fix other, still-broken, stuff in raytrace, vgui_controls, etc. But yay, mathlib.