### PR TITLE
Fix compile error of tier1.lib

### DIFF
--- a/public/tier1/strtools.h
+++ b/public/tier1/strtools.h
@@ -16,9 +16,9 @@
 #elif POSIX
 #include <ctype.h>
 #include <wchar.h>
-#include <math.h>
 #endif
 
+#include <math.h>
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
see https://github.com/alliedmodders/hl2sdk/issues/116

This is just a simple fix that when update to VS2022 17.4.1, it throws compile error that `log10` not found but it should exist.
> - Line is here: https://github.com/alliedmodders/hl2sdk/blob/csgo/public/tier1/strtools.h#L441
> - Screenshot is now under the issue.

N.B.: I'm using CMake to help me to update static libs, but I think this fix could help people who are using latest version of msvc/gcc/clang.