### PR TITLE
tf2: Add vscript headers

### DIFF
--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -340,6 +340,26 @@ typedef void * HINSTANCE;
 // Pull in the /analyze code annotations.
 #include "annotations.h"
 
+
+//-----------------------------------------------------------------------------
+// Stack-based allocation related helpers
+//-----------------------------------------------------------------------------
+#if defined( GNUC )
+	#define stackalloc( _size )		alloca( ALIGN_VALUE( _size, 16 ) )
+#ifdef _LINUX
+	#define mallocsize( _p )	( malloc_usable_size( _p ) )
+#elif defined(OSX)
+	#define mallocsize( _p )	( malloc_size( _p ) )
+#else
+#error
+#endif
+#elif defined ( _WIN32 )
+	#define stackalloc( _size )		_alloca( ALIGN_VALUE( _size, 16 ) )
+	#define mallocsize( _p )		( _msize( _p ) )
+#endif
+
+#define  stackfree( _p )			0
+
 // Linux had a few areas where it didn't construct objects in the same order that Windows does.
 // So when CVProfile::CVProfile() would access g_pMemAlloc, it would crash because the allocator wasn't initalized yet.
 #if defined(_LINUX) || defined(__APPLE__)

--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -358,8 +358,6 @@ typedef void * HINSTANCE;
 	#define mallocsize( _p )		( _msize( _p ) )
 #endif
 
-#define  stackfree( _p )			0
-
 // Linux had a few areas where it didn't construct objects in the same order that Windows does.
 // So when CVProfile::CVProfile() would access g_pMemAlloc, it would crash because the allocator wasn't initalized yet.
 #if defined(_LINUX) || defined(__APPLE__)

--- a/public/tier1/utlmemory.h
+++ b/public/tier1/utlmemory.h
@@ -1,4 +1,4 @@
-//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright (c) 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //
@@ -80,7 +80,10 @@ public:
 
 	// Can we use this index?
 	bool IsIdxValid( I i ) const;
-	static I InvalidIndex() { return ( I )-1; }
+
+	// Specify the invalid ('null') index that we'll only return on failure
+	static const I INVALID_INDEX = ( I )-1; // For use with COMPILE_TIME_ASSERT
+	static I InvalidIndex() { return INVALID_INDEX; }
 
 	// Gets the base address (can change when adding elements!)
 	T* Base();
@@ -90,6 +93,8 @@ public:
 	void SetExternalBuffer( T* pMemory, int numElements );
 	void SetExternalBuffer( const T* pMemory, int numElements );
 	void AssumeMemory( T *pMemory, int nSize );
+	T* Detach();
+	void *DetachMemory();
 
 	// Fast swap
 	void Swap( CUtlMemory< T, I > &mem );
@@ -133,7 +138,7 @@ protected:
 			const int MAX_GROW = 128;
 			if ( m_nGrowSize * sizeof(T) > MAX_GROW )
 			{
-				m_nGrowSize = MAX( 1, MAX_GROW / sizeof(T) );
+				m_nGrowSize = V_max( 1, MAX_GROW / sizeof(T) );
 			}
 		}
 #endif
@@ -169,9 +174,9 @@ public:
 
 	void Grow( int nCount = 1 )
 	{
-		if ( CUtlMemory<T, I>::IsExternallyAllocated() )
+		if ( this->IsExternallyAllocated() )
 		{
-			CUtlMemory<T, I>::ConvertToGrowableMemory( m_nMallocGrowSize );
+			this->ConvertToGrowableMemory( m_nMallocGrowSize );
 		}
 		BaseClass::Grow( nCount );
 	}
@@ -181,10 +186,10 @@ public:
 		if ( CUtlMemory<T>::m_nAllocationCount >= num )
 			return;
 
-		if ( CUtlMemory<T, I>::IsExternallyAllocated() )
+		if ( this->IsExternallyAllocated() )
 		{
 			// Can't grow a buffer whose memory was externally allocated 
-			CUtlMemory<T, I>::ConvertToGrowableMemory( m_nMallocGrowSize );
+			this->ConvertToGrowableMemory( m_nMallocGrowSize );
 		}
 
 		BaseClass::EnsureCapacity( num );
@@ -208,8 +213,11 @@ public:
 	CUtlMemoryFixed( T* pMemory, int numElements )			{ Assert( 0 ); 										}
 
 	// Can we use this index?
-	bool IsIdxValid( int i ) const							{ return (i >= 0) && (i < (int)SIZE); }
-	static int InvalidIndex()								{ return -1; }
+	bool IsIdxValid( int i ) const							{ return (i >= 0) && (i < SIZE); }
+
+	// Specify the invalid ('null') index that we'll only return on failure
+	static const int INVALID_INDEX = -1; // For use with COMPILE_TIME_ASSERT
+	static int InvalidIndex() { return INVALID_INDEX; }
 
 	// Gets the base address
 	T* Base()												{ if ( nAlignment == 0 ) return (T*)(&m_Memory[0]); else return (T*)AlignValue( &m_Memory[0], nAlignment ); }
@@ -232,7 +240,7 @@ public:
 	void Grow( int num = 1 )								{ Assert( 0 ); }
 
 	// Makes sure we've got at least this much memory
-	void EnsureCapacity( int num )							{ Assert( num <= (int)SIZE ); }
+	void EnsureCapacity( int num )							{ Assert( num <= SIZE ); }
 
 	// Memory deallocation
 	void Purge()											{}
@@ -264,6 +272,134 @@ public:
 private:
 	char m_Memory[ SIZE*sizeof(T) + nAlignment ];
 };
+
+#ifdef _LINUX
+#define REMEMBER_ALLOC_SIZE_FOR_VALGRIND 1
+#endif
+
+//-----------------------------------------------------------------------------
+// The CUtlMemoryConservative class:
+// A dynamic memory class that tries to minimize overhead (itself small, no custom grow factor)
+//-----------------------------------------------------------------------------
+template< typename T >
+class CUtlMemoryConservative
+{
+
+public:
+	// constructor, destructor
+	CUtlMemoryConservative( int nGrowSize = 0, int nInitSize = 0 ) : m_pMemory( NULL )
+	{
+#ifdef REMEMBER_ALLOC_SIZE_FOR_VALGRIND
+		m_nCurAllocSize = 0;
+#endif
+
+	}
+	CUtlMemoryConservative( T* pMemory, int numElements )								{ Assert( 0 ); }
+	~CUtlMemoryConservative()								{ if ( m_pMemory ) free( m_pMemory ); }
+
+	// Can we use this index?
+	bool IsIdxValid( int i ) const							{ return ( IsDebug() ) ? ( i >= 0 && i < NumAllocated() ) : ( i >= 0 ); }
+	static int InvalidIndex()								{ return -1; }
+
+	// Gets the base address
+	T* Base()												{ return m_pMemory; }
+	const T* Base() const									{ return m_pMemory; }
+
+	// element access
+	T& operator[]( int i )									{ Assert( IsIdxValid(i) ); return Base()[i];	}
+	const T& operator[]( int i ) const						{ Assert( IsIdxValid(i) ); return Base()[i];	}
+	T& Element( int i )										{ Assert( IsIdxValid(i) ); return Base()[i];	}
+	const T& Element( int i ) const							{ Assert( IsIdxValid(i) ); return Base()[i];	}
+
+	// Attaches the buffer to external memory....
+	void SetExternalBuffer( T* pMemory, int numElements )	{ Assert( 0 ); }
+
+	// Size
+	FORCEINLINE void RememberAllocSize( size_t sz )
+	{
+#ifdef REMEMBER_ALLOC_SIZE_FOR_VALGRIND
+		m_nCurAllocSize = sz;
+#endif
+	}
+
+	size_t AllocSize( void ) const
+	{
+#ifdef REMEMBER_ALLOC_SIZE_FOR_VALGRIND
+		return m_nCurAllocSize;
+#else
+		return ( m_pMemory ) ? g_pMemAlloc->GetSize( m_pMemory ) : 0;
+#endif
+	}
+
+	int NumAllocated() const
+	{
+		return AllocSize() / sizeof( T );
+	}
+	int Count() const
+	{
+		return NumAllocated();
+	}
+
+	FORCEINLINE void ReAlloc( size_t sz )
+	{
+		m_pMemory = (T*)realloc( m_pMemory, sz );
+		RememberAllocSize( sz );
+	}
+	// Grows the memory, so that at least allocated + num elements are allocated
+	void Grow( int num = 1 )
+	{
+		int nCurN = NumAllocated();
+		ReAlloc( ( nCurN + num ) * sizeof( T ) );
+	}
+
+	// Makes sure we've got at least this much memory
+	void EnsureCapacity( int num )
+	{
+		size_t nSize = sizeof( T ) * MAX( num, Count() );
+		ReAlloc( nSize );
+	}
+
+	// Memory deallocation
+	void Purge()
+	{
+		free( m_pMemory ); 
+		RememberAllocSize( 0 );
+		m_pMemory = NULL; 
+	}
+
+	// Purge all but the given number of elements
+	void Purge( int numElements )							{ ReAlloc( numElements * sizeof(T) ); }
+
+	// is the memory externally allocated?
+	bool IsExternallyAllocated() const						{ return false; }
+
+	// Set the size by which the memory grows
+	void SetGrowSize( int size )							{}
+
+	class Iterator_t
+	{
+	public:
+		Iterator_t( int i, int _limit ) : index( i ), limit( _limit ) {}
+		int index;
+		int limit;
+		bool operator==( const Iterator_t it ) const	{ return index == it.index; }
+		bool operator!=( const Iterator_t it ) const	{ return index != it.index; }
+	};
+	Iterator_t First() const							{ int limit = NumAllocated(); return Iterator_t( limit ? 0 : InvalidIndex(), limit ); }
+	Iterator_t Next( const Iterator_t &it ) const		{ return Iterator_t( ( it.index + 1 < it.limit ) ? it.index + 1 : InvalidIndex(), it.limit ); }
+	int GetIndex( const Iterator_t &it ) const			{ return it.index; }
+	bool IsIdxAfter( int i, const Iterator_t &it ) const { return i > it.index; }
+	bool IsValidIterator( const Iterator_t &it ) const	{ return IsIdxValid( it.index ) && ( it.index < it.limit ); }
+	Iterator_t InvalidIterator() const					{ return Iterator_t( InvalidIndex(), 0 ); }
+
+private:
+	T *m_pMemory;
+#ifdef REMEMBER_ALLOC_SIZE_FOR_VALGRIND
+	size_t m_nCurAllocSize;
+#endif
+
+};
+
 
 //-----------------------------------------------------------------------------
 // constructor, destructor
@@ -401,6 +537,24 @@ void CUtlMemory<T,I>::AssumeMemory( T* pMemory, int numElements )
 	m_nAllocationCount = numElements;
 }
 
+template< class T, class I >
+void *CUtlMemory<T,I>::DetachMemory()
+{
+	if ( IsExternallyAllocated() )
+		return NULL;
+
+	void *pMemory = m_pMemory;
+	m_pMemory = 0;
+	m_nAllocationCount = 0;
+	return pMemory;
+}
+
+template< class T, class I >
+inline T* CUtlMemory<T,I>::Detach()
+{
+	return (T*)DetachMemory();
+}
+
 
 //-----------------------------------------------------------------------------
 // element access
@@ -505,8 +659,10 @@ inline int CUtlMemory<T,I>::Count() const
 template< class T, class I >
 inline bool CUtlMemory<T,I>::IsIdxValid( I i ) const
 {
-	int idx = (int)i;
-	return idx >= 0 && idx < m_nAllocationCount;
+	// GCC warns if I is an unsigned type and we do a ">= 0" against it (since the comparison is always 0).
+	// We get the warning even if we cast inside the expression. It only goes away if we assign to another variable.
+	long x = i;
+	return ( x >= 0 ) && ( x < m_nAllocationCount );
 }
 
 //-----------------------------------------------------------------------------
@@ -561,14 +717,14 @@ void CUtlMemory<T,I>::Grow( int num )
 
 	UTLMEMORY_TRACK_FREE();
 
-	m_nAllocationCount = UtlMemory_CalcNewAllocationCount( m_nAllocationCount, m_nGrowSize, nAllocationRequested, sizeof(T) );
+	int nNewAllocationCount = UtlMemory_CalcNewAllocationCount( m_nAllocationCount, m_nGrowSize, nAllocationRequested, sizeof(T) );
 
 	// if m_nAllocationRequested wraps index type I, recalculate
-	if ( ( int )( I )m_nAllocationCount < nAllocationRequested )
+	if ( ( int )( I )nNewAllocationCount < nAllocationRequested )
 	{
-		if ( ( int )( I )m_nAllocationCount == 0 && ( int )( I )( m_nAllocationCount - 1 ) >= nAllocationRequested )
+		if ( ( int )( I )nNewAllocationCount == 0 && ( int )( I )( nNewAllocationCount - 1 ) >= nAllocationRequested )
 		{
-			--m_nAllocationCount; // deal w/ the common case of m_nAllocationCount == MAX_USHORT + 1
+			--nNewAllocationCount; // deal w/ the common case of m_nAllocationCount == MAX_USHORT + 1
 		}
 		else
 		{
@@ -578,12 +734,14 @@ void CUtlMemory<T,I>::Grow( int num )
 				Assert( 0 );
 				return;
 			}
-			while ( ( int )( I )m_nAllocationCount < nAllocationRequested )
+			while ( ( int )( I )nNewAllocationCount < nAllocationRequested )
 			{
-				m_nAllocationCount = ( m_nAllocationCount + nAllocationRequested ) / 2;
+				nNewAllocationCount = ( nNewAllocationCount + nAllocationRequested ) / 2;
 			}
 		}
 	}
+
+	m_nAllocationCount = nNewAllocationCount;
 
 	UTLMEMORY_TRACK_ALLOC();
 
@@ -760,7 +918,7 @@ CUtlMemoryAligned<T, nAlignment>::CUtlMemoryAligned( int nGrowSize, int nInitAll
 	CUtlMemory<T>::m_pMemory = 0; 
 	CUtlMemory<T>::m_nAllocationCount = nInitAllocationCount;
 	CUtlMemory<T>::m_nGrowSize = nGrowSize;
-	CUtlMemory<T>::ValidateGrowSize();
+	this->ValidateGrowSize();
 
 	// Alignment must be a power of two
 	COMPILE_TIME_ASSERT( (nAlignment & (nAlignment-1)) == 0 );
@@ -769,8 +927,8 @@ CUtlMemoryAligned<T, nAlignment>::CUtlMemoryAligned( int nGrowSize, int nInitAll
 	{
 		UTLMEMORY_TRACK_ALLOC();
 		MEM_ALLOC_CREDIT_CLASS();
-		CUtlMemory<T>::m_pMemory = (T*)_aligned_malloc( CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
-	}		
+		CUtlMemory<T>::m_pMemory = (T*)_aligned_malloc( nInitAllocationCount * sizeof(T), nAlignment );
+	}
 }
 
 template< class T, int nAlignment >
@@ -838,7 +996,7 @@ void CUtlMemoryAligned<T, nAlignment>::Grow( int num )
 {
 	Assert( num > 0 );
 
-	if ( CUtlMemory<T>::IsExternallyAllocated() )
+	if ( this->IsExternallyAllocated() )
 	{
 		// Can't grow a buffer whose memory was externally allocated 
 		Assert(0);
@@ -858,13 +1016,13 @@ void CUtlMemoryAligned<T, nAlignment>::Grow( int num )
 	if ( CUtlMemory<T>::m_pMemory )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
-		CUtlMemory<T>::m_pMemory = (T*)_aligned_realloc( CUtlMemory<T>::m_pMemory, CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
+		CUtlMemory<T>::m_pMemory = (T*)MemAlloc_ReallocAligned( CUtlMemory<T>::m_pMemory, CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
 		Assert( CUtlMemory<T>::m_pMemory );
 	}
 	else
 	{
 		MEM_ALLOC_CREDIT_CLASS();
-		CUtlMemory<T>::m_pMemory = (T*)_aligned_malloc( CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
+		CUtlMemory<T>::m_pMemory = (T*)MemAlloc_AllocAligned( CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
 		Assert( CUtlMemory<T>::m_pMemory );
 	}
 }
@@ -879,7 +1037,7 @@ inline void CUtlMemoryAligned<T, nAlignment>::EnsureCapacity( int num )
 	if ( CUtlMemory<T>::m_nAllocationCount >= num )
 		return;
 
-	if ( CUtlMemory<T>::IsExternallyAllocated() )
+	if ( this->IsExternallyAllocated() )
 	{
 		// Can't grow a buffer whose memory was externally allocated 
 		Assert(0);
@@ -895,12 +1053,12 @@ inline void CUtlMemoryAligned<T, nAlignment>::EnsureCapacity( int num )
 	if ( CUtlMemory<T>::m_pMemory )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
-		CUtlMemory<T>::m_pMemory = (T*)_aligned_realloc( CUtlMemory<T>::m_pMemory, CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
+		CUtlMemory<T>::m_pMemory = (T*)MemAlloc_ReallocAligned( CUtlMemory<T>::m_pMemory, CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
 	}
 	else
 	{
 		MEM_ALLOC_CREDIT_CLASS();
-		CUtlMemory<T>::m_pMemory = (T*)_aligned_malloc( CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
+		CUtlMemory<T>::m_pMemory = (T*)MemAlloc_AllocAligned( CUtlMemory<T>::m_nAllocationCount * sizeof(T), nAlignment );
 	}
 }
 
@@ -911,12 +1069,12 @@ inline void CUtlMemoryAligned<T, nAlignment>::EnsureCapacity( int num )
 template< class T, int nAlignment >
 void CUtlMemoryAligned<T, nAlignment>::Purge()
 {
-	if ( !CUtlMemory<T>::IsExternallyAllocated() )
+	if ( !this->IsExternallyAllocated() )
 	{
 		if ( CUtlMemory<T>::m_pMemory )
 		{
 			UTLMEMORY_TRACK_FREE();
-			_aligned_free( CUtlMemory<T>::m_pMemory );
+			MemAlloc_FreeAligned( CUtlMemory<T>::m_pMemory );
 			CUtlMemory<T>::m_pMemory = 0;
 		}
 		CUtlMemory<T>::m_nAllocationCount = 0;

--- a/public/tier1/utlvector.h
+++ b/public/tier1/utlvector.h
@@ -25,7 +25,9 @@
 #include "tier1/strtools.h"
 
 #define FOR_EACH_VEC( vecName, iteratorName ) \
-	for ( int iteratorName = 0; iteratorName < vecName.Count(); iteratorName++ )
+	for ( int iteratorName = 0; iteratorName < (vecName).Count(); iteratorName++ )
+#define FOR_EACH_VEC_BACK( vecName, iteratorName ) \
+	for ( int iteratorName = (vecName).Count()-1; iteratorName >= 0; iteratorName-- )
 
 //-----------------------------------------------------------------------------
 // The CUtlVector class:
@@ -65,9 +67,7 @@ public:
 	const T* Base() const					{ return m_Memory.Base(); }
 
 	// Returns the number of elements in the vector
-	// SIZE IS DEPRECATED!
 	int Count() const;
-	int Size() const;	// don't use me!
 
 	// Is element index valid?
 	bool IsValidIndex( int i ) const;
@@ -87,13 +87,16 @@ public:
 
 	// Adds multiple elements, uses default constructor
 	int AddMultipleToHead( int num );
-	int AddMultipleToTail( int num, const T *pToCopy=NULL );	   
-	int InsertMultipleBefore( int elem, int num, const T *pToCopy=NULL );	// If pToCopy is set, then it's an array of length 'num' and
+	int AddMultipleToTail( int num );	   
+	int AddMultipleToTail( int num, const T *pToCopy );	   
+	int InsertMultipleBefore( int elem, int num );
+	int InsertMultipleBefore( int elem, int num, const T *pToCopy );
 	int InsertMultipleAfter( int elem, int num );
 
 	// Calls RemoveAll() then AddMultipleToTail.
 	void SetSize( int size );
 	void SetCount( int count );
+	void SetCountNonDestructively( int count ); //sets count by adding or removing elements to tail TODO: This should probably be the default behavior for SetCount
 	
 	// Calls SetSize and copies each element.
 	void CopyArray( const T *pArray, int size );
@@ -106,6 +109,7 @@ public:
 
 	// Finds an element (element needs operator== defined)
 	int Find( const T& src ) const;
+	void FillWithValue( const T& src );
 
 	bool HasElement( const T& src ) const;
 
@@ -119,7 +123,10 @@ public:
 	void FastRemove( int elem );	// doesn't preserve order
 	void Remove( int elem );		// preserves order, shifts elements
 	bool FindAndRemove( const T& src );	// removes first occurrence of src, preserves order, shifts elements
+	bool FindAndFastRemove( const T& src );	// removes first occurrence of src, doesn't preserve order
 	void RemoveMultiple( int elem, int num );	// preserves order, shifts elements
+	void RemoveMultipleFromHead(int num); // removes num elements from tail
+	void RemoveMultipleFromTail(int num); // removes num elements from tail
 	void RemoveAll();				// doesn't deallocate memory
 
 	// Memory deallocation
@@ -156,6 +163,7 @@ protected:
 	CAllocator m_Memory;
 	int m_Size;
 
+#ifndef _X360
 	// For easier access to the elements through the debugger
 	// it's in release builds so this can be used in libraries correctly
 	T *m_pElements;
@@ -164,6 +172,9 @@ protected:
 	{
 		m_pElements = Base();
 	}
+#else
+	inline void ResetDbgInfo() {}
+#endif
 };
 
 
@@ -177,8 +188,9 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-// The CUtlVectorFixed class:
-// A array class with a fixed allocation scheme
+// The CUtlVectorMT class:
+// A array class with some sort of mutex protection. Not sure which operations are protected from
+// which others.
 //-----------------------------------------------------------------------------
 
 template< class BASE_UTLVECTOR, class MUTEX_TYPE = CThreadFastMutex >
@@ -211,8 +223,8 @@ public:
 
 
 //-----------------------------------------------------------------------------
-// The CUtlVectorFixed class:
-// A array class with a fixed allocation scheme
+// The CUtlVectorFixedGrowable class:
+// A array class with a fixed allocation scheme backed by a dynamic one
 //-----------------------------------------------------------------------------
 template< class T, size_t MAX_SIZE >
 class CUtlVectorFixedGrowable : public CUtlVector< T, CUtlMemoryFixedGrowable<T, MAX_SIZE > >
@@ -224,6 +236,274 @@ public:
 	CUtlVectorFixedGrowable( int growSize = 0 ) : BaseClass( growSize, MAX_SIZE ) {}
 };
 
+
+//-----------------------------------------------------------------------------
+// The CUtlVectorConservative class:
+// A array class with a conservative allocation scheme
+//-----------------------------------------------------------------------------
+template< class T >
+class CUtlVectorConservative : public CUtlVector< T, CUtlMemoryConservative<T> >
+{
+	typedef CUtlVector< T, CUtlMemoryConservative<T> > BaseClass;
+public:
+
+	// constructor, destructor
+	CUtlVectorConservative( int growSize = 0, int initSize = 0 ) : BaseClass( growSize, initSize ) {}
+	CUtlVectorConservative( T* pMemory, int numElements ) : BaseClass( pMemory, numElements ) {}
+};
+
+
+//-----------------------------------------------------------------------------
+// The CUtlVectorUltra Conservative class:
+// A array class with a very conservative allocation scheme, with customizable allocator
+// Especialy useful if you have a lot of vectors that are sparse, or if you're
+// carefully packing holders of vectors
+//-----------------------------------------------------------------------------
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200) // warning C4200: nonstandard extension used : zero-sized array in struct/union
+#pragma warning(disable : 4815 ) // warning C4815: 'staticData' : zero-sized array in stack object will have no elements
+#endif
+
+class CUtlVectorUltraConservativeAllocator
+{
+public:
+	static void *Alloc( size_t nSize )
+	{
+		return malloc( nSize );
+	}
+
+	static void *Realloc( void *pMem, size_t nSize )
+	{
+		return realloc( pMem, nSize );
+	}
+
+	static void Free( void *pMem )
+	{
+		free( pMem );
+	}
+
+	static size_t GetSize( void *pMem )
+	{
+		return mallocsize( pMem );
+	}
+
+};
+
+template <typename T, typename A = CUtlVectorUltraConservativeAllocator >
+class CUtlVectorUltraConservative : private A
+{
+public:
+	CUtlVectorUltraConservative()
+	{
+		m_pData = StaticData();
+	}
+
+	~CUtlVectorUltraConservative()
+	{
+		RemoveAll();
+	}
+
+	int Count() const
+	{
+		return m_pData->m_Size;
+	}
+
+	static int InvalidIndex()
+	{
+		return -1;
+	}
+
+	inline bool IsValidIndex( int i ) const
+	{
+		return (i >= 0) && (i < Count());
+	}
+
+	T& operator[]( int i )
+	{
+		Assert( IsValidIndex( i ) );
+		return m_pData->m_Elements[i];
+	}
+
+	const T& operator[]( int i ) const
+	{
+		Assert( IsValidIndex( i ) );
+		return m_pData->m_Elements[i];
+	}
+
+	T& Element( int i )
+	{
+		Assert( IsValidIndex( i ) );
+		return m_pData->m_Elements[i];
+	}
+
+	const T& Element( int i ) const
+	{
+		Assert( IsValidIndex( i ) );
+		return m_pData->m_Elements[i];
+	}
+
+	void EnsureCapacity( int num )
+	{
+		int nCurCount = Count();
+		if ( num <= nCurCount )
+		{
+			return;
+		}
+		if ( m_pData == StaticData() )
+		{
+			m_pData = (Data_t *)A::Alloc( sizeof(int) + ( num * sizeof(T) ) );
+			m_pData->m_Size = 0;
+		}
+		else
+		{
+			int nNeeded = sizeof(int) + ( num * sizeof(T) );
+			int nHave = A::GetSize( m_pData );
+			if ( nNeeded > nHave )
+			{
+				m_pData = (Data_t *)A::Realloc( m_pData, nNeeded );
+			}
+		}
+	}
+
+	int AddToTail( const T& src )
+	{
+		int iNew = Count();
+		EnsureCapacity( Count() + 1 );
+		m_pData->m_Elements[iNew] = src;
+		m_pData->m_Size++;
+		return iNew;
+	}
+
+	void RemoveAll()
+	{
+		if ( Count() )
+		{
+			for (int i = m_pData->m_Size; --i >= 0; )
+			{
+				Destruct(&m_pData->m_Elements[i]);
+			}
+		}
+		if ( m_pData != StaticData() )
+		{
+			A::Free( m_pData );
+			m_pData = StaticData();
+
+		}
+	}
+
+	void PurgeAndDeleteElements()
+	{
+		if ( m_pData != StaticData() )
+		{
+			for( int i=0; i < m_pData->m_Size; i++ )
+			{
+				delete Element(i);
+			}
+			RemoveAll();
+		}
+	}
+
+	void FastRemove( int elem )
+	{
+		Assert( IsValidIndex(elem) );
+
+		Destruct( &Element(elem) );
+		if (Count() > 0)
+		{
+			if ( elem != m_pData->m_Size -1 )
+				memcpy( &Element(elem), &Element(m_pData->m_Size-1), sizeof(T) );
+			--m_pData->m_Size;
+		}
+		if ( !m_pData->m_Size )
+		{
+			A::Free( m_pData );
+			m_pData = StaticData();
+		}
+	}
+
+	void Remove( int elem )
+	{
+		Destruct( &Element(elem) );
+		ShiftElementsLeft(elem);
+		--m_pData->m_Size;
+		if ( !m_pData->m_Size )
+		{
+			A::Free( m_pData );
+			m_pData = StaticData();
+		}
+	}
+
+	int Find( const T& src ) const
+	{
+		int nCount = Count();
+		for ( int i = 0; i < nCount; ++i )
+		{
+			if (Element(i) == src)
+				return i;
+		}
+		return -1;
+	}
+
+	bool FindAndRemove( const T& src )
+	{
+		int elem = Find( src );
+		if ( elem != -1 )
+		{
+			Remove( elem );
+			return true;
+		}
+		return false;
+	}
+
+
+	bool FindAndFastRemove( const T& src )
+	{
+		int elem = Find( src );
+		if ( elem != -1 )
+		{
+			FastRemove( elem );
+			return true;
+		}
+		return false;
+	}
+
+	struct Data_t
+	{
+		int m_Size;
+		T m_Elements[];
+	};
+
+	Data_t *m_pData;
+private:
+	void ShiftElementsLeft( int elem, int num = 1 )
+	{
+		int Size = Count();
+		Assert( IsValidIndex(elem) || ( Size == 0 ) || ( num == 0 ));
+		int numToMove = Size - elem - num;
+		if ((numToMove > 0) && (num > 0))
+		{
+			Q_memmove( &Element(elem), &Element(elem+num), numToMove * sizeof(T) );
+
+#ifdef _DEBUG
+			Q_memset( &Element(Size-num), 0xDD, num * sizeof(T) );
+#endif
+		}
+	}
+
+
+
+	static Data_t *StaticData()
+	{
+		static Data_t staticData;
+		Assert( staticData.m_Size == 0 );
+		return &staticData;
+	}
+};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 //-----------------------------------------------------------------------------
 // The CCopyableUtlVector class:
@@ -241,6 +521,8 @@ public:
 	virtual ~CCopyableUtlVector() {}
 	CCopyableUtlVector( CCopyableUtlVector const& vec ) { CopyArray( vec.Base(), vec.Count() ); }
 };
+
+// TODO (Ilya): It seems like all the functions in CUtlVector are simple enough that they should be inlined.
 
 //-----------------------------------------------------------------------------
 // constructor, destructor
@@ -284,24 +566,28 @@ inline CUtlVector<T, A>& CUtlVector<T, A>::operator=( const CUtlVector<T, A> &ot
 template< typename T, class A >
 inline T& CUtlVector<T, A>::operator[]( int i )
 {
+	Assert( i < m_Size );
 	return m_Memory[ i ];
 }
 
 template< typename T, class A >
 inline const T& CUtlVector<T, A>::operator[]( int i ) const
 {
+	Assert( i < m_Size );
 	return m_Memory[ i ];
 }
 
 template< typename T, class A >
 inline T& CUtlVector<T, A>::Element( int i )
 {
+	Assert( i < m_Size );
 	return m_Memory[ i ];
 }
 
 template< typename T, class A >
 inline const T& CUtlVector<T, A>::Element( int i ) const
 {
+	Assert( i < m_Size );
 	return m_Memory[ i ];
 }
 
@@ -337,12 +623,6 @@ inline const T& CUtlVector<T, A>::Tail() const
 //-----------------------------------------------------------------------------
 // Count
 //-----------------------------------------------------------------------------
-template< typename T, class A >
-inline int CUtlVector<T, A>::Size() const
-{
-	return m_Size;
-}
-
 template< typename T, class A >
 inline int CUtlVector<T, A>::Count() const
 {
@@ -441,7 +721,9 @@ template< typename T, class A >
 void CUtlVector<T, A>::EnsureCount( int num )
 {
 	if (Count() < num)
+	{
 		AddMultipleToTail( num - Count() );
+	}
 }
 
 
@@ -560,10 +842,16 @@ inline int CUtlVector<T, A>::AddMultipleToHead( int num )
 }
 
 template< typename T, class A >
+inline int CUtlVector<T, A>::AddMultipleToTail( int num )
+{
+	return InsertMultipleBefore( m_Size, num );
+}
+
+template< typename T, class A >
 inline int CUtlVector<T, A>::AddMultipleToTail( int num, const T *pToCopy )
 {
 	// Can't insert something that's in the list... reallocation may hose us
-	Assert( (Base() == NULL) || !pToCopy || (pToCopy + num < Base()) || (pToCopy >= (Base() + Count()) ) ); 
+	Assert( (Base() == NULL) || !pToCopy || (pToCopy + num <= Base()) || (pToCopy >= (Base() + Count()) ) ); 
 
 	return InsertMultipleBefore( m_Size, num, pToCopy );
 }
@@ -589,6 +877,14 @@ inline void CUtlVector<T, A>::SetSize( int size )
 }
 
 template< typename T, class A >
+void CUtlVector<T, A>::SetCountNonDestructively( int count )
+{
+	int delta = count - m_Size;
+	if(delta > 0) AddMultipleToTail( delta );
+	else if(delta < 0) RemoveMultipleFromTail( -delta );
+}
+
+template< typename T, class A >
 void CUtlVector<T, A>::CopyArray( const T *pArray, int size )
 {
 	// Can't insert something that's in the list... reallocation may hose us
@@ -606,7 +902,9 @@ void CUtlVector<T, A>::Swap( CUtlVector< T, A > &vec )
 {
 	m_Memory.Swap( vec.m_Memory );
 	V_swap( m_Size, vec.m_Size );
+#ifndef _X360
 	V_swap( m_pElements, vec.m_pElements );
+#endif
 }
 
 template< typename T, class A >
@@ -617,15 +915,37 @@ int CUtlVector<T, A>::AddVectorToTail( CUtlVector const &src )
 	int base = Count();
 	
 	// Make space.
-	AddMultipleToTail( src.Count() );
+	int nSrcCount = src.Count();
+	EnsureCapacity( base + nSrcCount );
 
 	// Copy the elements.	
-	for ( int i=0; i < src.Count(); i++ )
+	m_Size += nSrcCount;
+	for ( int i=0; i < nSrcCount; i++ )
 	{
-		(*this)[base + i] = src[i];
+		CopyConstruct( &Element(base+i), src[i] );
+	}
+	return base;
+}
+
+template< typename T, class A >
+inline int CUtlVector<T, A>::InsertMultipleBefore( int elem, int num )
+{
+	if( num == 0 )
+		return elem;
+
+	// Can insert at the end
+	Assert( (elem == Count()) || IsValidIndex(elem) );
+
+	GrowVector(num);
+	ShiftElementsRight( elem, num );
+
+	// Invoke default constructors
+	for (int i = 0; i < num; ++i )
+	{
+		Construct( &Element( elem+i ) );
 	}
 
-	return base;
+	return elem;
 }
 
 template< typename T, class A >
@@ -638,18 +958,21 @@ inline int CUtlVector<T, A>::InsertMultipleBefore( int elem, int num, const T *p
 	Assert( (elem == Count()) || IsValidIndex(elem) );
 
 	GrowVector(num);
-	ShiftElementsRight(elem, num);
+	ShiftElementsRight( elem, num );
 
 	// Invoke default constructors
-	for (int i = 0; i < num; ++i)
-		Construct( &Element(elem+i) );
-
-	// Copy stuff in?
-	if ( pToInsert )
+	if ( !pToInsert )
+	{
+		for (int i = 0; i < num; ++i )
+		{
+			Construct( &Element( elem+i ) );
+		}
+	}
+	else
 	{
 		for ( int i=0; i < num; i++ )
 		{
-			Element( elem+i ) = pToInsert[i];
+			CopyConstruct( &Element( elem+i ), pToInsert[i] );
 		}
 	}
 
@@ -672,6 +995,15 @@ int CUtlVector<T, A>::Find( const T& src ) const
 }
 
 template< typename T, class A >
+void CUtlVector<T, A>::FillWithValue( const T& src )
+{
+	for ( int i = 0; i < Count(); i++ )
+	{
+		Element(i) = src;
+	}
+}
+
+template< typename T, class A >
 bool CUtlVector<T, A>::HasElement( const T& src ) const
 {
 	return ( Find(src) >= 0 );
@@ -689,7 +1021,8 @@ void CUtlVector<T, A>::FastRemove( int elem )
 	Destruct( &Element(elem) );
 	if (m_Size > 0)
 	{
-		memcpy( &Element(elem), &Element(m_Size-1), sizeof(T) );
+		if ( elem != m_Size -1 )
+			memcpy( &Element(elem), &Element(m_Size-1), sizeof(T) );
 		--m_Size;
 	}
 }
@@ -715,6 +1048,18 @@ bool CUtlVector<T, A>::FindAndRemove( const T& src )
 }
 
 template< typename T, class A >
+bool CUtlVector<T, A>::FindAndFastRemove( const T& src )
+{
+	int elem = Find( src );
+	if ( elem != -1 )
+	{
+		FastRemove( elem );
+		return true;
+	}
+	return false;
+}
+
+template< typename T, class A >
 void CUtlVector<T, A>::RemoveMultiple( int elem, int num )
 {
 	Assert( elem >= 0 );
@@ -724,6 +1069,29 @@ void CUtlVector<T, A>::RemoveMultiple( int elem, int num )
 		Destruct(&Element(i));
 
 	ShiftElementsLeft(elem, num);
+	m_Size -= num;
+}
+
+template< typename T, class A >
+void CUtlVector<T, A>::RemoveMultipleFromHead( int num )
+{
+	Assert( num <= Count() );
+
+	for (int i = num; --i >= 0; )
+		Destruct(&Element(i));
+
+	ShiftElementsLeft(0, num);
+	m_Size -= num;
+}
+
+template< typename T, class A >
+void CUtlVector<T, A>::RemoveMultipleFromTail( int num )
+{
+	Assert( num <= Count() );
+
+	for (int i = m_Size-num; i < m_Size; i++)
+		Destruct(&Element(i));
+
 	m_Size -= num;
 }
 
@@ -819,19 +1187,6 @@ public:
 		return strcmp( *sz1, *sz2 );
 	}
 
-	inline void PurgeAndDeleteElements()
-	{
-		for( int i=0; i < m_Size; i++ )
-		{
-			delete [] Element(i);
-		}
-		Purge();
-	}
-
-	~CUtlStringList( void )
-	{
-		this->PurgeAndDeleteElements();
-	}
 };
 
 

--- a/public/vscript/ivscript.h
+++ b/public/vscript/ivscript.h
@@ -1,0 +1,1412 @@
+//========== Copyright © 2008, Valve Corporation, All rights reserved. ========
+//
+// Purpose: VScript
+//
+// Overview
+// --------
+// VScript is an abstract binding layer that allows code to expose itself to 
+// multiple scripting languages in a uniform format. Code can expose 
+// functions, classes, and data to the scripting languages, and can also 
+// call functions that reside in scripts.
+// 
+// Initializing
+// ------------
+// 
+// To create a script virtual machine (VM), grab the global instance of 
+// IScriptManager, call CreateVM, then call Init on the returned VM. Right 
+// now you can have multiple VMs, but only VMs for a specific language.
+// 
+// Exposing functions and classes
+// ------------------------------
+// 
+// To expose a C++ function to the scripting system, you just need to fill out a 
+// description block. Using templates, the system will automatically deduce 
+// all of the binding requirements (parameters and return values). Functions 
+// are limited as to what the types of the parameters can be. See ScriptVariant_t.
+// 
+// 		extern IScriptVM *pScriptVM;
+// 		bool Foo( int );
+// 		void Bar();
+// 		float FooBar( int, const char * );
+// 		float OverlyTechnicalName( bool );
+// 
+// 		void RegisterFuncs()
+// 		{
+// 			ScriptRegisterFunction( pScriptVM, Foo );
+// 			ScriptRegisterFunction( pScriptVM, Bar );
+// 			ScriptRegisterFunction( pScriptVM, FooBar );
+// 			ScriptRegisterFunctionNamed( pScriptVM, OverlyTechnicalName, "SimpleName" );
+// 		}
+// 
+// 		class CMyClass
+// 		{
+// 		public:
+// 			bool Foo( int );
+// 			void Bar();
+// 			float FooBar( int, const char * );
+// 			float OverlyTechnicalName( bool );
+// 		};
+// 
+// 		BEGIN_SCRIPTDESC_ROOT( CMyClass )
+// 			DEFINE_SCRIPTFUNC( Foo )
+// 			DEFINE_SCRIPTFUNC( Bar )
+// 			DEFINE_SCRIPTFUNC( FooBar )
+// 			DEFINE_SCRIPTFUNC_NAMED( OverlyTechnicalName, "SimpleMemberName" )
+// 		END_SCRIPTDESC();
+// 
+// 		class CMyDerivedClass : public CMyClass
+// 		{
+// 		public:
+// 			float DerivedFunc() const;
+// 		};
+// 
+// 		BEGIN_SCRIPTDESC( CMyDerivedClass, CMyClass )
+// 			DEFINE_SCRIPTFUNC( DerivedFunc )
+// 		END_SCRIPTDESC();
+// 
+// 		CMyDerivedClass derivedInstance;
+// 
+// 		void AnotherFunction()
+// 		{
+// 			// Manual class exposure
+// 			pScriptVM->RegisterClass( GetScriptDescForClass( CMyClass ) );
+// 
+// 			// Auto registration by instance
+// 			pScriptVM->RegisterInstance( &derivedInstance, "theInstance" );
+// 		}
+// 
+// Classes with "DEFINE_SCRIPT_CONSTRUCTOR()" in their description can be instanced within scripts
+//
+// Scopes
+// ------
+// Scripts can either be run at the global scope, or in a user defined scope. In the latter case,
+// all "globals" within the script are actually in the scope. This can be used to bind private
+// data spaces with C++ objects.
+//
+// Calling a function on a script
+// ------------------------------
+// Generally, use the "Call" functions. This example is the equivalent of DoIt("Har", 6.0, 99).
+//
+// 		hFunction = pScriptVM->LookupFunction( "DoIt", hScope );
+// 		pScriptVM->Call( hFunction, hScope, true, NULL, "Har", 6.0, 99 );
+// 
+//=============================================================================
+
+#ifndef IVSCRIPT_H
+#define IVSCRIPT_H
+
+#include "platform.h"
+#include "datamap.h"
+#include "appframework/IAppSystem.h"
+#include "tier1/functors.h"
+#include "tier0/memdbgon.h"
+
+#if defined( _WIN32 )
+#pragma once
+#endif
+
+#ifdef VSCRIPT_DLL_EXPORT
+#define VSCRIPT_INTERFACE	DLL_EXPORT
+#define VSCRIPT_OVERLOAD	DLL_GLOBAL_EXPORT
+#define VSCRIPT_CLASS		DLL_CLASS_EXPORT
+#else
+#define VSCRIPT_INTERFACE	DLL_IMPORT
+#define VSCRIPT_OVERLOAD	DLL_GLOBAL_IMPORT
+#define VSCRIPT_CLASS		DLL_CLASS_IMPORT
+#endif
+
+class CUtlBuffer;
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+
+#define VSCRIPT_INTERFACE_VERSION		"VScriptManager009"
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+
+class IScriptVM;
+
+enum ScriptLanguage_t
+{
+	SL_NONE,
+	SL_GAMEMONKEY,
+	SL_SQUIRREL,
+	SL_LUA,
+	SL_PYTHON,
+
+	SL_DEFAULT = SL_SQUIRREL
+};
+
+class IScriptManager : public IAppSystem
+{
+public:
+	virtual IScriptVM *CreateVM( ScriptLanguage_t language = SL_DEFAULT ) = 0;
+	virtual void DestroyVM( IScriptVM * ) = 0;
+};
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+DECLARE_POINTER_HANDLE( HSCRIPT );
+#define INVALID_HSCRIPT ((HSCRIPT)-1)
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+enum ExtendedFieldType
+{
+	FIELD_TYPEUNKNOWN = FIELD_TYPECOUNT,
+	FIELD_CSTRING,
+	FIELD_HSCRIPT,
+	FIELD_VARIANT,
+};
+
+typedef int ScriptDataType_t;
+struct ScriptVariant_t;
+
+template <typename T> struct ScriptDeducer { /*enum { FIELD_TYPE = FIELD_TYPEUNKNOWN };*/ };
+#define DECLARE_DEDUCE_FIELDTYPE( fieldType, type ) template<> struct ScriptDeducer<type> { enum { FIELD_TYPE = fieldType }; };
+
+DECLARE_DEDUCE_FIELDTYPE( FIELD_VOID,		void );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_FLOAT,		float );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_CSTRING,	const char * );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_CSTRING,	char * );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_VECTOR,		Vector );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_VECTOR,		const Vector &);
+DECLARE_DEDUCE_FIELDTYPE( FIELD_INTEGER,	int );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_BOOLEAN,	bool );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_CHARACTER,	char );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_HSCRIPT,	HSCRIPT );
+DECLARE_DEDUCE_FIELDTYPE( FIELD_VARIANT,	ScriptVariant_t );
+
+#define ScriptDeduceType( T ) ScriptDeducer<T>::FIELD_TYPE
+
+template <typename T>
+inline const char * ScriptFieldTypeName() 
+{
+	T::using_unknown_script_type(); 
+}
+
+#define DECLARE_NAMED_FIELDTYPE( fieldType, strName ) template <> inline const char * ScriptFieldTypeName<fieldType>() { return strName; }
+DECLARE_NAMED_FIELDTYPE( void,	"void" );
+DECLARE_NAMED_FIELDTYPE( float,	"float" );
+DECLARE_NAMED_FIELDTYPE( const char *,	"cstring" );
+DECLARE_NAMED_FIELDTYPE( char *,	"cstring" );
+DECLARE_NAMED_FIELDTYPE( Vector,	"vector" );
+DECLARE_NAMED_FIELDTYPE( const Vector&,	"vector" );
+DECLARE_NAMED_FIELDTYPE( int,	"integer" );
+DECLARE_NAMED_FIELDTYPE( bool,	"boolean" );
+DECLARE_NAMED_FIELDTYPE( char,	"character" );
+DECLARE_NAMED_FIELDTYPE( HSCRIPT,	"hscript" );
+DECLARE_NAMED_FIELDTYPE( ScriptVariant_t,	"variant" );
+
+inline const char * ScriptFieldTypeName( int16 eType)
+{
+	switch( eType )
+	{
+	case FIELD_VOID:	return "void";
+	case FIELD_FLOAT:	return "float";
+	case FIELD_CSTRING:	return "cstring";
+	case FIELD_VECTOR:	return "vector";
+	case FIELD_INTEGER:	return "integer";
+	case FIELD_BOOLEAN:	return "boolean";
+	case FIELD_CHARACTER:	return "character";
+	case FIELD_HSCRIPT:	return "hscript";
+	case FIELD_VARIANT:	return "variant";
+	default:	return "unknown_script_type";
+	}
+}
+
+//---------------------------------------------------------
+
+struct ScriptFuncDescriptor_t
+{
+	ScriptFuncDescriptor_t()
+	{
+		m_pszFunction = NULL;
+		m_ReturnType = FIELD_TYPEUNKNOWN;
+		m_pszDescription = NULL;
+	}
+
+	const char *m_pszScriptName;
+	const char *m_pszFunction;
+	const char *m_pszDescription;
+	ScriptDataType_t m_ReturnType;
+	CUtlVector<ScriptDataType_t> m_Parameters;
+};
+
+
+//---------------------------------------------------------
+
+// Prefix a script description with this in order to not show the function or class in help
+#define SCRIPT_HIDE "@"
+
+// Prefix a script description of a class to indicate it is a singleton and the single instance should be in the help
+#define SCRIPT_SINGLETON "!"
+
+// Prefix a script description with this to indicate it should be represented using an alternate name
+#define SCRIPT_ALIAS( alias, description ) "#" alias ":" description
+
+//---------------------------------------------------------
+
+enum ScriptFuncBindingFlags_t
+{
+	SF_MEMBER_FUNC	= 0x01,
+};
+
+typedef bool (*ScriptBindingFunc_t)( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn );
+
+struct ScriptFunctionBinding_t
+{
+	ScriptFuncDescriptor_t	m_desc;
+	ScriptBindingFunc_t		m_pfnBinding;
+	void *					m_pFunction;
+	unsigned				m_flags;
+};
+
+//---------------------------------------------------------
+class IScriptInstanceHelper
+{
+public:
+	virtual void *GetProxied( void *p )												{ return p; }
+	virtual bool ToString( void *p, char *pBuf, int bufSize )						{ return false; }
+	virtual void *BindOnRead( HSCRIPT hInstance, void *pOld, const char *pszId )	{ return NULL; }
+};
+
+//---------------------------------------------------------
+
+struct ScriptClassDesc_t
+{
+	ScriptClassDesc_t() : m_pszScriptName( 0 ), m_pszClassname( 0 ), m_pszDescription( 0 ), m_pBaseDesc( 0 ), m_pfnConstruct( 0 ), m_pfnDestruct( 0 ), pHelper(NULL) {}
+
+	const char *						m_pszScriptName;
+	const char *						m_pszClassname;
+	const char *						m_pszDescription;
+	ScriptClassDesc_t *					m_pBaseDesc;
+	CUtlVector<ScriptFunctionBinding_t> m_FunctionBindings;
+
+	void *(*m_pfnConstruct)();
+	void (*m_pfnDestruct)( void *);
+	IScriptInstanceHelper *				pHelper; // optional helper
+};
+
+//---------------------------------------------------------
+// A simple variant type. Intentionally not full featured (no implicit conversion, no memory management)
+//---------------------------------------------------------
+
+enum SVFlags_t
+{
+	SV_FREE = 0x01,
+};
+
+#pragma warning(push)
+#pragma warning(disable:4800)
+struct ScriptVariant_t
+{
+	ScriptVariant_t() :						m_flags( 0 ), m_type( FIELD_VOID )		{ m_pVector = 0; }
+	ScriptVariant_t( int val ) :			m_flags( 0 ), m_type( FIELD_INTEGER )	{ m_int = val;}
+	ScriptVariant_t( float val ) :			m_flags( 0 ), m_type( FIELD_FLOAT )		{ m_float = val; }
+	ScriptVariant_t( double val ) :			m_flags( 0 ), m_type( FIELD_FLOAT )		{ m_float = (float)val; }
+	ScriptVariant_t( char val ) :			m_flags( 0 ), m_type( FIELD_CHARACTER )	{ m_char = val; }
+	ScriptVariant_t( bool val ) :			m_flags( 0 ), m_type( FIELD_BOOLEAN )	{ m_bool = val; }
+	ScriptVariant_t( HSCRIPT val ) :		m_flags( 0 ), m_type( FIELD_HSCRIPT )	{ m_hScript = val; }
+
+	ScriptVariant_t( const Vector &val, bool bCopy = false ) :	m_flags( 0 ), m_type( FIELD_VECTOR )	{ if ( !bCopy ) { m_pVector = &val; } else { m_pVector = new Vector( val ); m_flags |= SV_FREE; } }
+	ScriptVariant_t( const Vector *val, bool bCopy = false ) :	m_flags( 0 ), m_type( FIELD_VECTOR )	{ if ( !bCopy ) { m_pVector = val; } else { m_pVector = new Vector( *val ); m_flags |= SV_FREE; } }
+	ScriptVariant_t( const char *val , bool bCopy = false ) :	m_flags( 0 ), m_type( FIELD_CSTRING )	{ if ( !bCopy ) { m_pszString = val; } else { m_pszString = strdup( val ); m_flags |= SV_FREE; } }
+
+	bool IsNull() const						{ return (m_type == FIELD_VOID ); }
+
+	operator int() const					{ Assert( m_type == FIELD_INTEGER );	return m_int; }
+	operator float() const					{ Assert( m_type == FIELD_FLOAT );		return m_float; }
+	operator const char *() const			{ Assert( m_type == FIELD_CSTRING );	return ( m_pszString ) ? m_pszString : ""; }
+	operator const Vector &() const			{ Assert( m_type == FIELD_VECTOR );		static Vector vecNull(0, 0, 0); return (m_pVector) ? *m_pVector : vecNull; }
+	operator char() const					{ Assert( m_type == FIELD_CHARACTER );	return m_char; }
+	operator bool() const					{ Assert( m_type == FIELD_BOOLEAN );	return m_bool; }
+	operator HSCRIPT() const				{ Assert( m_type == FIELD_HSCRIPT );	return m_hScript; }
+
+	void operator=( int i ) 				{ m_type = FIELD_INTEGER; m_int = i; }
+	void operator=( float f ) 				{ m_type = FIELD_FLOAT; m_float = f; }
+	void operator=( double f ) 				{ m_type = FIELD_FLOAT; m_float = (float)f; }
+	void operator=( const Vector &vec )		{ m_type = FIELD_VECTOR; m_pVector = &vec; }
+	void operator=( const Vector *vec )		{ m_type = FIELD_VECTOR; m_pVector = vec; }
+	void operator=( const char *psz )		{ m_type = FIELD_CSTRING; m_pszString = psz; }
+	void operator=( char c )				{ m_type = FIELD_CHARACTER; m_char = c; }
+	void operator=( bool b ) 				{ m_type = FIELD_BOOLEAN; m_bool = b; }
+	void operator=( HSCRIPT h ) 			{ m_type = FIELD_HSCRIPT; m_hScript = h; }
+
+	void Free()								{ if ( ( m_flags & SV_FREE ) && ( m_type == FIELD_HSCRIPT || m_type == FIELD_VECTOR || m_type == FIELD_CSTRING ) ) delete m_pszString; } // Generally only needed for return results
+
+	template <typename T>
+	T Get()
+	{
+		T value;
+		AssignTo( &value );
+		return value;
+	}
+
+	template <typename T>
+	bool AssignTo( T *pDest )
+	{
+		ScriptDataType_t destType = ScriptDeduceType( T );
+		if ( destType == FIELD_TYPEUNKNOWN )
+		{
+			DevWarning( "Unable to convert script variant to unknown type\n" );
+		}
+		if ( destType == m_type )
+		{
+			*pDest = *this;
+			return true;
+		}
+
+		if ( m_type != FIELD_VECTOR && m_type != FIELD_CSTRING && destType != FIELD_VECTOR && destType != FIELD_CSTRING )
+		{
+			switch ( m_type )
+			{
+			case FIELD_VOID:		*pDest = 0; break;
+			case FIELD_INTEGER:		*pDest = m_int; return true;
+			case FIELD_FLOAT:		*pDest = m_float; return true;
+			case FIELD_CHARACTER:	*pDest = m_char; return true;
+			case FIELD_BOOLEAN:		*pDest = m_bool; return true;
+			case FIELD_HSCRIPT:		*pDest = m_hScript; return true;
+			}
+		}
+		else
+		{
+			DevWarning( "No free conversion of %s script variant to %s right now\n",
+				ScriptFieldTypeName( m_type ), ScriptFieldTypeName<T>() );
+			if ( destType != FIELD_VECTOR )
+			{
+				*pDest = 0;
+			}
+		}
+		return false;
+	}
+
+	bool AssignTo( float *pDest )
+	{
+		switch( m_type )
+		{
+		case FIELD_VOID:		*pDest = 0; return false;
+		case FIELD_INTEGER:		*pDest = m_int; return true;
+		case FIELD_FLOAT:		*pDest = m_float; return true;
+		case FIELD_BOOLEAN:		*pDest = m_bool; return true;
+		default:
+			DevWarning( "No conversion from %s to float now\n", ScriptFieldTypeName( m_type ) );
+			return false;
+		}
+	}
+
+	bool AssignTo( int *pDest )
+	{
+		switch( m_type )
+		{
+		case FIELD_VOID:		*pDest = 0; return false;
+		case FIELD_INTEGER:		*pDest = m_int; return true;
+		case FIELD_FLOAT:		*pDest = m_float; return true;
+		case FIELD_BOOLEAN:		*pDest = m_bool; return true;
+		default:
+			DevWarning( "No conversion from %s to int now\n", ScriptFieldTypeName( m_type ) );
+			return false;
+		}
+	}
+
+	bool AssignTo( bool *pDest )
+	{
+		switch( m_type )
+		{
+		case FIELD_VOID:		*pDest = 0; return false;
+		case FIELD_INTEGER:		*pDest = m_int; return true;
+		case FIELD_FLOAT:		*pDest = m_float; return true;
+		case FIELD_BOOLEAN:		*pDest = m_bool; return true;
+		default:
+			DevWarning( "No conversion from %s to bool now\n", ScriptFieldTypeName( m_type ) );
+			return false;
+		}
+	}
+
+	bool AssignTo( char **pDest )
+	{
+		DevWarning( "No free conversion of string or vector script variant right now\n" );
+		// If want to support this, probably need to malloc string and require free on other side [3/24/2008 tom]
+		*pDest = "";
+		return false;
+	}
+
+	bool AssignTo( ScriptVariant_t *pDest )
+	{
+		pDest->m_type = m_type;
+		if ( m_type == FIELD_VECTOR ) 
+		{
+			pDest->m_pVector = new Vector;
+			((Vector *)(pDest->m_pVector))->Init( m_pVector->x, m_pVector->y, m_pVector->z );
+			pDest->m_flags |= SV_FREE;
+		}
+		else if ( m_type == FIELD_CSTRING ) 
+		{
+			pDest->m_pszString = strdup( m_pszString );
+			pDest->m_flags |= SV_FREE;
+		}
+		else
+		{
+			pDest->m_int = m_int;
+		}
+		return false;
+	}
+
+	union
+	{
+		int				m_int;
+		float			m_float;
+		const char *	m_pszString;
+		const Vector *	m_pVector;
+		char			m_char;
+		bool			m_bool;
+		HSCRIPT			m_hScript;
+	};
+
+	int16				m_type;
+	int16				m_flags;
+
+private:
+};
+
+#define SCRIPT_VARIANT_NULL ScriptVariant_t()
+
+#pragma warning(pop)
+
+
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#include "vscript_templates.h"
+
+// Lower level macro primitives
+#define ScriptInitFunctionBinding( pScriptFunction, func )									ScriptInitFunctionBindingNamed( pScriptFunction, func, #func )
+#define ScriptInitFunctionBindingNamed( pScriptFunction, func, scriptName )					do { ScriptInitFuncDescriptorNamed( (&(pScriptFunction)->m_desc), func, scriptName ); (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( &func ); (pScriptFunction)->m_pFunction = (void *)&func; } while (0)
+
+#define ScriptInitMemberFunctionBinding( pScriptFunction, class, func )						ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, #func )
+#define ScriptInitMemberFunctionBindingNamed( pScriptFunction, class, func, scriptName )	ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, scriptName )
+#define ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, scriptName ) 		do { ScriptInitMemberFuncDescriptor_( (&(pScriptFunction)->m_desc), class, func, scriptName ); (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( ((class *)0), &class::func ); 	(pScriptFunction)->m_pFunction = ScriptConvertFuncPtrToVoid( &class::func ); (pScriptFunction)->m_flags = SF_MEMBER_FUNC;  } while (0)
+
+#define ScriptInitClassDesc( pClassDesc, class, pBaseClassDesc )							ScriptInitClassDescNamed( pClassDesc, class, pBaseClassDesc, #class )
+#define ScriptInitClassDescNamed( pClassDesc, class, pBaseClassDesc, scriptName )			ScriptInitClassDescNamed_( pClassDesc, class, pBaseClassDesc, scriptName )
+#define ScriptInitClassDescNoBase( pClassDesc, class )										ScriptInitClassDescNoBaseNamed( pClassDesc, class, #class )
+#define ScriptInitClassDescNoBaseNamed( pClassDesc, class, scriptName )						ScriptInitClassDescNamed_( pClassDesc, class, NULL, scriptName )
+#define ScriptInitClassDescNamed_( pClassDesc, class, pBaseClassDesc, scriptName )			do { (pClassDesc)->m_pszScriptName = scriptName; (pClassDesc)->m_pszClassname = #class; (pClassDesc)->m_pBaseDesc = pBaseClassDesc; } while ( 0 )
+
+#define ScriptAddFunctionToClassDesc( pClassDesc, class, func, description  )				ScriptAddFunctionToClassDescNamed( pClassDesc, class, func, #func, description )
+#define ScriptAddFunctionToClassDescNamed( pClassDesc, class, func, scriptName, description ) do { ScriptFunctionBinding_t *pBinding = &((pClassDesc)->m_FunctionBindings[(pClassDesc)->m_FunctionBindings.AddToTail()]); pBinding->m_desc.m_pszDescription = description; ScriptInitMemberFunctionBindingNamed( pBinding, class, func, scriptName );  } while (0)
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#define ScriptRegisterFunction( pVM, func, description )									ScriptRegisterFunctionNamed( pVM, func, #func, description )
+#define ScriptRegisterFunctionNamed( pVM, func, scriptName, description )					do { static ScriptFunctionBinding_t binding; binding.m_desc.m_pszDescription = description; binding.m_desc.m_Parameters.RemoveAll(); ScriptInitFunctionBindingNamed( &binding, func, scriptName ); pVM->RegisterFunction( &binding ); } while (0)
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#define ALLOW_SCRIPT_ACCESS() 																template <typename T> friend ScriptClassDesc_t *GetScriptDesc(T *);
+
+#define BEGIN_SCRIPTDESC( className, baseClass, description )								BEGIN_SCRIPTDESC_NAMED( className, baseClass, #className, description )
+#define BEGIN_SCRIPTDESC_ROOT( className, description )										BEGIN_SCRIPTDESC_ROOT_NAMED( className, #className, description )
+
+#if defined( COMPILER_MSVC )
+	#define DEFINE_SCRIPTDESC_FUNCTION( className, baseClass ) \
+		ScriptClassDesc_t * GetScriptDesc( className * )
+#else
+	#define DEFINE_SCRIPTDESC_FUNCTION( className, baseClass ) \
+		template <> ScriptClassDesc_t * GetScriptDesc<baseClass>( baseClass *); \
+		template <> ScriptClassDesc_t * GetScriptDesc<className>( className *)
+#endif
+
+#define BEGIN_SCRIPTDESC_NAMED( className, baseClass, scriptName, description ) \
+	ScriptClassDesc_t g_##className##_ScriptDesc; \
+	DEFINE_SCRIPTDESC_FUNCTION( className, baseClass ) \
+	{ \
+		static bool bInitialized; \
+		if ( bInitialized ) \
+		{ \
+			return &g_##className##_ScriptDesc; \
+		} \
+		\
+		bInitialized = true; \
+		\
+		typedef className _className; \
+		ScriptClassDesc_t *pDesc = &g_##className##_ScriptDesc; \
+		pDesc->m_pszDescription = description; \
+		ScriptInitClassDescNamed( pDesc, className, GetScriptDescForClass( baseClass ), scriptName ); \
+		ScriptClassDesc_t *pInstanceHelperBase = pDesc->m_pBaseDesc; \
+		while ( pInstanceHelperBase ) \
+		{ \
+			if ( pInstanceHelperBase->pHelper ) \
+			{ \
+				pDesc->pHelper = pInstanceHelperBase->pHelper; \
+				break; \
+			} \
+			pInstanceHelperBase = pInstanceHelperBase->m_pBaseDesc; \
+		}
+
+
+#define BEGIN_SCRIPTDESC_ROOT_NAMED( className, scriptName, description ) \
+	BEGIN_SCRIPTDESC_NAMED( className, ScriptNoBase_t, scriptName, description )
+
+#define END_SCRIPTDESC() \
+		return pDesc; \
+	}
+
+#define DEFINE_SCRIPTFUNC( func, description )												DEFINE_SCRIPTFUNC_NAMED( func, #func, description )
+#define DEFINE_SCRIPTFUNC_NAMED( func, scriptName, description )							ScriptAddFunctionToClassDescNamed( pDesc, _className, func, scriptName, description );
+#define DEFINE_SCRIPT_CONSTRUCTOR()															ScriptAddConstructorToClassDesc( pDesc, _className );
+#define DEFINE_SCRIPT_INSTANCE_HELPER( p )													pDesc->pHelper = (p);
+
+template <typename T> ScriptClassDesc_t *GetScriptDesc(T *);
+
+struct ScriptNoBase_t;
+template <> inline ScriptClassDesc_t *GetScriptDesc<ScriptNoBase_t>( ScriptNoBase_t *) { return NULL; }
+
+#define GetScriptDescForClass( className ) GetScriptDesc( ( className *)NULL )
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+template <typename T>
+class CScriptConstructor
+{
+public:
+	static void *Construct()		{ return new T; }
+	static void Destruct( void *p )	{ delete (T *)p; }
+};
+
+#define ScriptAddConstructorToClassDesc( pClassDesc, class )								do { (pClassDesc)->m_pfnConstruct = &CScriptConstructor<class>::Construct; (pClassDesc)->m_pfnDestruct = &CScriptConstructor<class>::Destruct; } while (0)
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+enum ScriptErrorLevel_t
+{
+	SCRIPT_LEVEL_WARNING	= 0,
+	SCRIPT_LEVEL_ERROR,
+};
+
+typedef void ( *ScriptOutputFunc_t )( const char *pszText );
+typedef bool ( *ScriptErrorFunc_t )( ScriptErrorLevel_t eLevel, const char *pszText );
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#ifdef RegisterClass
+#undef RegisterClass
+#endif
+
+enum ScriptStatus_t
+{
+	SCRIPT_ERROR = -1,
+	SCRIPT_DONE,
+	SCRIPT_RUNNING,
+};
+
+class IScriptVM
+{
+public:
+	virtual bool Init() = 0;
+	virtual void Shutdown() = 0;
+
+	virtual bool ConnectDebugger() = 0;
+	virtual void DisconnectDebugger() = 0;
+
+	virtual ScriptLanguage_t GetLanguage() = 0;
+	virtual const char *GetLanguageName() = 0;
+
+	virtual void AddSearchPath( const char *pszSearchPath ) = 0;
+
+	//--------------------------------------------------------
+ 
+ 	virtual bool Frame( float simTime ) = 0;
+
+	//--------------------------------------------------------
+	// Simple script usage
+	//--------------------------------------------------------
+	virtual ScriptStatus_t Run( const char *pszScript, bool bWait = true ) = 0;
+	inline ScriptStatus_t Run( const unsigned char *pszScript, bool bWait = true ) { return Run( (char *)pszScript, bWait ); }
+
+	//--------------------------------------------------------
+	// Compilation
+	//--------------------------------------------------------
+ 	virtual HSCRIPT CompileScript( const char *pszScript, const char *pszId = NULL ) = 0;
+	inline HSCRIPT CompileScript( const unsigned char *pszScript, const char *pszId = NULL ) { return CompileScript( (char *)pszScript, pszId ); }
+	virtual void ReleaseScript( HSCRIPT ) = 0;
+
+	//--------------------------------------------------------
+	// Execution of compiled
+	//--------------------------------------------------------
+	virtual ScriptStatus_t Run( HSCRIPT hScript, HSCRIPT hScope = NULL, bool bWait = true ) = 0;
+	virtual ScriptStatus_t Run( HSCRIPT hScript, bool bWait ) = 0;
+
+	//--------------------------------------------------------
+	// Scope
+	//--------------------------------------------------------
+	virtual HSCRIPT CreateScope( const char *pszScope, HSCRIPT hParent = NULL ) = 0;
+	virtual void ReleaseScope( HSCRIPT hScript ) = 0;
+
+	//--------------------------------------------------------
+	// Script functions
+	//--------------------------------------------------------
+	virtual HSCRIPT LookupFunction( const char *pszFunction, HSCRIPT hScope = NULL ) = 0;
+	virtual void ReleaseFunction( HSCRIPT hScript ) = 0;
+
+	//--------------------------------------------------------
+	// Script functions (raw, use Call())
+	//--------------------------------------------------------
+	virtual ScriptStatus_t ExecuteFunction( HSCRIPT hFunction, ScriptVariant_t *pArgs, int nArgs, ScriptVariant_t *pReturn, HSCRIPT hScope, bool bWait ) = 0;
+
+	//--------------------------------------------------------
+	// External functions
+	//--------------------------------------------------------
+	virtual void RegisterFunction( ScriptFunctionBinding_t *pScriptFunction ) = 0;
+
+	//--------------------------------------------------------
+	// External classes
+	//--------------------------------------------------------
+	virtual bool RegisterClass( ScriptClassDesc_t *pClassDesc ) = 0;
+
+	//--------------------------------------------------------
+	// External instances. Note class will be auto-registered.
+	//--------------------------------------------------------
+
+	virtual HSCRIPT RegisterInstance( ScriptClassDesc_t *pDesc, void *pInstance ) = 0;
+	virtual void SetInstanceUniqeId( HSCRIPT hInstance, const char *pszId ) = 0;
+	template <typename T> HSCRIPT RegisterInstance( T *pInstance )																	{ return RegisterInstance( GetScriptDesc( pInstance ), pInstance );	}
+	template <typename T> HSCRIPT RegisterInstance( T *pInstance, const char *pszInstance, HSCRIPT hScope = NULL)					{ HSCRIPT hInstance = RegisterInstance( GetScriptDesc( pInstance ), pInstance ); SetValue( hScope, pszInstance, hInstance ); return hInstance; }
+	virtual void RemoveInstance( HSCRIPT ) = 0;
+	void RemoveInstance( HSCRIPT hInstance, const char *pszInstance, HSCRIPT hScope = NULL )										{ ClearValue( hScope, pszInstance ); RemoveInstance( hInstance ); }
+	void RemoveInstance( const char *pszInstance, HSCRIPT hScope = NULL )															{ ScriptVariant_t val; if ( GetValue( hScope, pszInstance, &val ) ) { if ( val.m_type == FIELD_HSCRIPT ) { RemoveInstance( val, pszInstance, hScope ); } ReleaseValue( val ); } }
+
+	virtual void *GetInstanceValue( HSCRIPT hInstance, ScriptClassDesc_t *pExpectedType = NULL ) = 0;
+
+	//----------------------------------------------------------------------------
+
+	virtual bool GenerateUniqueKey( const char *pszRoot, char *pBuf, int nBufSize ) = 0;
+
+	//----------------------------------------------------------------------------
+
+	virtual bool ValueExists( HSCRIPT hScope, const char *pszKey ) = 0;
+	bool ValueExists( const char *pszKey )																							{ return ValueExists( NULL, pszKey ); }
+
+	virtual bool SetValue( HSCRIPT hScope, const char *pszKey, const char *pszValue ) = 0;
+	virtual bool SetValue( HSCRIPT hScope, const char *pszKey, const ScriptVariant_t &value ) = 0;
+	bool SetValue( const char *pszKey, const ScriptVariant_t &value )																{ return SetValue(NULL, pszKey, value ); }
+
+	virtual void CreateTable( ScriptVariant_t &Table ) = 0;
+	virtual int	GetNumTableEntries( HSCRIPT hScope ) = 0;
+	virtual int GetKeyValue( HSCRIPT hScope, int nIterator, ScriptVariant_t *pKey, ScriptVariant_t *pValue ) = 0;
+
+	virtual bool GetValue( HSCRIPT hScope, const char *pszKey, ScriptVariant_t *pValue ) = 0;
+	bool GetValue( const char *pszKey, ScriptVariant_t *pValue )																	{ return GetValue(NULL, pszKey, pValue ); }
+	virtual void ReleaseValue( ScriptVariant_t &value ) = 0;
+
+	virtual bool ClearValue( HSCRIPT hScope, const char *pszKey ) = 0;
+	bool ClearValue( const char *pszKey)																							{ return ClearValue( NULL, pszKey ); }
+
+	//----------------------------------------------------------------------------
+
+	virtual void WriteState( CUtlBuffer *pBuffer ) = 0;
+	virtual void ReadState( CUtlBuffer *pBuffer ) = 0;
+	virtual void RemoveOrphanInstances() = 0;
+
+	virtual void DumpState() = 0;
+
+	virtual void SetOutputCallback( ScriptOutputFunc_t pFunc ) = 0;
+	virtual void SetErrorCallback( ScriptErrorFunc_t pFunc ) = 0;
+
+	//----------------------------------------------------------------------------
+
+	virtual bool RaiseException( const char *pszExceptionText ) = 0;
+
+	//----------------------------------------------------------------------------
+	// Call API
+	//
+	// Note for string and vector return types, the caller must delete the pointed to memory
+	//----------------------------------------------------------------------------
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope = NULL, bool bWait = true, ScriptVariant_t *pReturn = NULL )
+	{
+		return ExecuteFunction( hFunction, NULL, 0, pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1 )
+	{
+		ScriptVariant_t args[1]; args[0] = arg1;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2 )
+	{
+		ScriptVariant_t args[2]; args[0] = arg1; args[1] = arg2;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3 )
+	{
+		ScriptVariant_t args[3]; args[0] = arg1; args[1] = arg2; args[2] = arg3;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4 )
+	{
+		ScriptVariant_t args[4]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5 )
+	{
+		ScriptVariant_t args[5]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6 )
+	{
+		ScriptVariant_t args[6]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7 )
+	{
+		ScriptVariant_t args[7]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8 )
+	{
+		ScriptVariant_t args[8]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9 )
+	{
+		ScriptVariant_t args[9]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10 )
+	{
+		ScriptVariant_t args[10]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11 )
+	{
+		ScriptVariant_t args[11]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12 )
+	{
+		ScriptVariant_t args[12]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13 )
+	{
+		ScriptVariant_t args[13]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13;
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13, typename ARG_TYPE_14>
+	ScriptStatus_t Call( HSCRIPT hFunction, HSCRIPT hScope, bool bWait, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13, ARG_TYPE_14 arg14 )
+	{
+		ScriptVariant_t args[14]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13; args[13] = arg14; 
+		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
+	}
+
+};
+
+
+//-----------------------------------------------------------------------------
+// Script scope helper class
+//-----------------------------------------------------------------------------
+
+class CDefScriptScopeBase
+{
+public:
+	static IScriptVM *GetVM()
+	{
+		extern IScriptVM *g_pScriptVM;
+		return g_pScriptVM;
+	}
+};
+
+template <class BASE_CLASS = CDefScriptScopeBase>
+class CScriptScopeT : public CDefScriptScopeBase
+{
+public:
+	CScriptScopeT() :
+		m_hScope( INVALID_HSCRIPT ),
+		m_flags( 0 )
+	{
+	}
+
+	~CScriptScopeT()
+	{
+		Term();
+	}
+
+	bool IsInitialized()
+	{
+		return m_hScope != INVALID_HSCRIPT;
+	}
+
+	bool Init( const char *pszName )
+	{
+		m_hScope = GetVM()->CreateScope( pszName );
+		return ( m_hScope != NULL );
+	}
+
+	bool Init( HSCRIPT hScope, bool bExternal = true )
+	{
+		if ( bExternal )
+		{
+			m_flags |= EXTERNAL;
+		}
+		m_hScope = hScope;
+		return ( m_hScope != NULL );
+	}
+
+	bool InitGlobal()
+	{
+		Assert( 0 ); // todo [3/24/2008 tom]
+		m_hScope = GetVM()->CreateScope( "" );
+		return ( m_hScope != NULL );
+	}
+
+	void Term()
+	{
+		if ( m_hScope != INVALID_HSCRIPT )
+		{
+			IScriptVM *pVM = GetVM();
+			if ( pVM )
+			{
+				for ( int i = 0; i < m_FuncHandles.Count(); i++ )
+				{
+					pVM->ReleaseFunction( *m_FuncHandles[i] );
+				}
+			}
+			m_FuncHandles.Purge();
+			if ( m_hScope && pVM && !(m_flags & EXTERNAL) )
+			{
+				pVM->ReleaseScope( m_hScope );
+			}
+			m_hScope = INVALID_HSCRIPT;
+		}
+		m_flags = 0;
+	}
+
+	void InvalidateCachedValues()
+	{
+		IScriptVM *pVM = GetVM();
+		for ( int i = 0; i < m_FuncHandles.Count(); i++ )
+		{
+			if ( *m_FuncHandles[i] )
+				pVM->ReleaseFunction( *m_FuncHandles[i] );
+			*m_FuncHandles[i] = INVALID_HSCRIPT;
+		}
+		m_FuncHandles.RemoveAll();
+	}
+
+	operator HSCRIPT()
+	{
+		return ( m_hScope != INVALID_HSCRIPT ) ? m_hScope : NULL;
+	}
+
+	bool ValueExists( const char *pszKey )																							{ return GetVM()->ValueExists( m_hScope, pszKey ); }
+	bool SetValue( const char *pszKey, const ScriptVariant_t &value )																{ return GetVM()->SetValue(m_hScope, pszKey, value ); }
+	bool GetValue( const char *pszKey, ScriptVariant_t *pValue )																	{ return GetVM()->GetValue(m_hScope, pszKey, pValue ); }
+	void ReleaseValue( ScriptVariant_t &value )																						{ GetVM()->ReleaseValue( value ); }
+	bool ClearValue( const char *pszKey)																							{ return GetVM()->ClearValue( m_hScope, pszKey ); }
+
+	ScriptStatus_t Run( HSCRIPT hScript )
+	{
+		InvalidateCachedValues();
+		return GetVM()->Run( hScript, m_hScope );
+	}
+
+	ScriptStatus_t Run( const char *pszScriptText, const char *pszScriptName = NULL )
+	{
+		InvalidateCachedValues();
+		HSCRIPT hScript = GetVM()->CompileScript( pszScriptText, pszScriptName );
+		if ( hScript )
+		{
+			ScriptStatus_t result = GetVM()->Run( hScript, m_hScope );
+			GetVM()->ReleaseScript( hScript );
+			return result; 
+		}
+		return SCRIPT_ERROR;
+	}
+
+	ScriptStatus_t Run( const unsigned char *pszScriptText, const char *pszScriptName = NULL )
+	{
+		return Run( (const char *)pszScriptText, pszScriptName);
+	}
+
+	HSCRIPT LookupFunction( const char *pszFunction )
+	{
+		return GetVM()->LookupFunction( pszFunction, m_hScope );
+	}
+
+	void ReleaseFunction( HSCRIPT hScript )
+	{
+		GetVM()->ReleaseFunction( hScript );
+	}
+
+	bool FunctionExists( const char *pszFunction )
+	{
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		GetVM()->ReleaseFunction( hFunction );
+		return ( hFunction != NULL ) ;
+	}
+
+	//-----------------------------------------------------
+
+	enum Flags_t
+	{
+		EXTERNAL = 0x01,
+	};
+
+	//-----------------------------------------------------
+
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn = NULL )
+	{
+		return GetVM()->ExecuteFunction( hFunction, NULL, 0, pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1 )
+	{
+		ScriptVariant_t args[1]; args[0] = arg1;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2 )
+	{
+		ScriptVariant_t args[2]; args[0] = arg1; args[1] = arg2;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3 )
+	{
+		ScriptVariant_t args[3]; args[0] = arg1; args[1] = arg2; args[2] = arg3;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4 )
+	{
+		ScriptVariant_t args[4]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5 )
+	{
+		ScriptVariant_t args[5]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6 )
+	{
+		ScriptVariant_t args[6]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7 )
+	{
+		ScriptVariant_t args[7]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8 )
+	{
+		ScriptVariant_t args[8]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9 )
+	{
+		ScriptVariant_t args[9]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10 )
+	{
+		ScriptVariant_t args[10]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11 )
+	{
+		ScriptVariant_t args[11]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12 )
+	{
+		ScriptVariant_t args[12]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13 )
+	{
+		ScriptVariant_t args[13]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13;
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13, typename ARG_TYPE_14>
+	ScriptStatus_t Call( HSCRIPT hFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13, ARG_TYPE_14 arg14 )
+	{
+		ScriptVariant_t args[14]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13; args[13] = arg14; 
+		return GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+	}
+
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn = NULL )
+	{
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, NULL, 0, pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1 )
+	{
+		ScriptVariant_t args[1]; args[0] = arg1;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2 )
+	{
+		ScriptVariant_t args[2]; args[0] = arg1; args[1] = arg2;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3 )
+	{
+		ScriptVariant_t args[3]; args[0] = arg1; args[1] = arg2; args[2] = arg3;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4 )
+	{
+		ScriptVariant_t args[4]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5 )
+	{
+		ScriptVariant_t args[5]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6 )
+	{
+		ScriptVariant_t args[6]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7 )
+	{
+		ScriptVariant_t args[7]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8 )
+	{
+		ScriptVariant_t args[8]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9 )
+	{
+		ScriptVariant_t args[9]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10 )
+	{
+		ScriptVariant_t args[10]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11 )
+	{
+		ScriptVariant_t args[11]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12 )
+	{
+		ScriptVariant_t args[12]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13 )
+	{
+		ScriptVariant_t args[13]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13;
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+	template <typename ARG_TYPE_1, typename ARG_TYPE_2, typename	ARG_TYPE_3,	typename ARG_TYPE_4, typename ARG_TYPE_5, typename ARG_TYPE_6, typename ARG_TYPE_7, typename ARG_TYPE_8, typename ARG_TYPE_9, typename ARG_TYPE_10, typename ARG_TYPE_11, typename ARG_TYPE_12, typename ARG_TYPE_13, typename ARG_TYPE_14>
+	ScriptStatus_t Call( const char *pszFunction, ScriptVariant_t *pReturn, ARG_TYPE_1 arg1, ARG_TYPE_2 arg2, ARG_TYPE_3 arg3, ARG_TYPE_4 arg4, ARG_TYPE_5 arg5, ARG_TYPE_6 arg6, ARG_TYPE_7 arg7, ARG_TYPE_8 arg8, ARG_TYPE_9 arg9, ARG_TYPE_10 arg10, ARG_TYPE_11 arg11, ARG_TYPE_12 arg12, ARG_TYPE_13 arg13, ARG_TYPE_14 arg14 )
+	{
+		ScriptVariant_t args[14]; args[0] = arg1; args[1] = arg2; args[2] = arg3; args[3] = arg4; args[4] = arg5; args[5] = arg6; args[6] = arg7; args[7] = arg8; args[8] = arg9; args[9] = arg10; args[10] = arg11; args[11] = arg12; args[12] = arg13; args[13] = arg14; 
+		HSCRIPT hFunction = GetVM()->LookupFunction( pszFunction, m_hScope );
+		if ( !hFunction )
+			return SCRIPT_ERROR;
+		ScriptStatus_t status = GetVM()->ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, m_hScope, true );
+		GetVM()->ReleaseFunction( hFunction );
+		return status;
+	}
+
+protected:
+	HSCRIPT m_hScope;
+	int m_flags;
+	CUtlVectorConservative<HSCRIPT *> m_FuncHandles;
+};
+
+typedef CScriptScopeT<> CScriptScope;
+
+#define VScriptAddEnumToScope_( scope, enumVal, scriptName )	(scope).SetValue( scriptName, (int)enumVal )
+#define VScriptAddEnumToScope( scope, enumVal )					VScriptAddEnumToScope_( scope, enumVal, #enumVal )
+
+#define VScriptAddEnumToRoot( enumVal )					g_pScriptVM->SetValue( #enumVal, (int)enumVal )
+
+//-----------------------------------------------------------------------------
+// Script function proxy support
+//-----------------------------------------------------------------------------
+
+class CScriptFuncHolder
+{
+public:
+	CScriptFuncHolder() : hFunction( INVALID_HSCRIPT ) {}
+	bool IsValid()	{ return ( hFunction != INVALID_HSCRIPT ); }
+	bool IsNull()	{ return ( !hFunction ); }
+	HSCRIPT hFunction;
+};
+
+#define DEFINE_SCRIPT_PROXY_GUTS( FuncName, N ) \
+	CScriptFuncHolder m_hScriptFunc_##FuncName; \
+	template < typename RET_TYPE FUNC_TEMPLATE_ARG_PARAMS_##N> \
+	bool FuncName( RET_TYPE *pRetVal FUNC_ARG_FORMAL_PARAMS_##N ) \
+	{ \
+		if ( !m_hScriptFunc_##FuncName.IsValid() ) \
+		{ \
+			m_hScriptFunc_##FuncName.hFunction = LookupFunction( #FuncName ); \
+			m_FuncHandles.AddToTail( &m_hScriptFunc_##FuncName.hFunction ); \
+		} \
+		\
+		if ( !m_hScriptFunc_##FuncName.IsNull() ) \
+		{ \
+			ScriptVariant_t returnVal; \
+			ScriptStatus_t result = Call( m_hScriptFunc_##FuncName.hFunction, &returnVal, FUNC_CALL_ARGS_##N ); \
+			if ( result != SCRIPT_ERROR ) \
+			{ \
+				returnVal.AssignTo( pRetVal ); \
+				returnVal.Free(); \
+				return true; \
+			} \
+		} \
+		return false; \
+	}
+
+#define DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, N ) \
+	CScriptFuncHolder m_hScriptFunc_##FuncName; \
+	template < FUNC_SOLO_TEMPLATE_ARG_PARAMS_##N> \
+	bool FuncName( FUNC_PROXY_ARG_FORMAL_PARAMS_##N ) \
+	{ \
+		if ( !m_hScriptFunc_##FuncName.IsValid() ) \
+		{ \
+			m_hScriptFunc_##FuncName.hFunction = LookupFunction( #FuncName ); \
+			m_FuncHandles.AddToTail( &m_hScriptFunc_##FuncName.hFunction ); \
+		} \
+		\
+		if ( !m_hScriptFunc_##FuncName.IsNull() ) \
+		{ \
+			ScriptStatus_t result = Call( m_hScriptFunc_##FuncName.hFunction, NULL, FUNC_CALL_ARGS_##N ); \
+			if ( result != SCRIPT_ERROR ) \
+			{ \
+				return true; \
+			} \
+		} \
+		return false; \
+	}
+
+#define DEFINE_SCRIPT_PROXY_0V( FuncName ) \
+	CScriptFuncHolder m_hScriptFunc_##FuncName; \
+	bool FuncName() \
+	{ \
+		if ( !m_hScriptFunc_##FuncName.IsValid() ) \
+		{ \
+			m_hScriptFunc_##FuncName.hFunction = LookupFunction( #FuncName ); \
+			m_FuncHandles.AddToTail( &m_hScriptFunc_##FuncName.hFunction ); \
+		} \
+		\
+		if ( !m_hScriptFunc_##FuncName.IsNull() ) \
+		{ \
+			ScriptStatus_t result = Call( m_hScriptFunc_##FuncName.hFunction, NULL ); \
+			if ( result != SCRIPT_ERROR ) \
+			{ \
+				return true; \
+			} \
+		} \
+		return false; \
+	}
+
+#define DEFINE_SCRIPT_PROXY_0( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 0 )
+#define DEFINE_SCRIPT_PROXY_1( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 1 )
+#define DEFINE_SCRIPT_PROXY_2( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 2 )
+#define DEFINE_SCRIPT_PROXY_3( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 3 )
+#define DEFINE_SCRIPT_PROXY_4( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 4 )
+#define DEFINE_SCRIPT_PROXY_5( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 5 )
+#define DEFINE_SCRIPT_PROXY_6( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 6 )
+#define DEFINE_SCRIPT_PROXY_7( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 7 )
+#define DEFINE_SCRIPT_PROXY_8( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 8 )
+#define DEFINE_SCRIPT_PROXY_9( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 9 )
+#define DEFINE_SCRIPT_PROXY_10( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 10 )
+#define DEFINE_SCRIPT_PROXY_11( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 11 )
+#define DEFINE_SCRIPT_PROXY_12( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 12 )
+#define DEFINE_SCRIPT_PROXY_13( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 13 )
+#define DEFINE_SCRIPT_PROXY_14( FuncName ) DEFINE_SCRIPT_PROXY_GUTS( FuncName, 14 )
+
+#define DEFINE_SCRIPT_PROXY_1V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 1 )
+#define DEFINE_SCRIPT_PROXY_2V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 2 )
+#define DEFINE_SCRIPT_PROXY_3V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 3 )
+#define DEFINE_SCRIPT_PROXY_4V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 4 )
+#define DEFINE_SCRIPT_PROXY_5V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 5 )
+#define DEFINE_SCRIPT_PROXY_6V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 6 )
+#define DEFINE_SCRIPT_PROXY_7V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 7 )
+#define DEFINE_SCRIPT_PROXY_8V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 8 )
+#define DEFINE_SCRIPT_PROXY_9V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 9 )
+#define DEFINE_SCRIPT_PROXY_10V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 10 )
+#define DEFINE_SCRIPT_PROXY_11V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 11 )
+#define DEFINE_SCRIPT_PROXY_12V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 12 )
+#define DEFINE_SCRIPT_PROXY_13V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 13 )
+#define DEFINE_SCRIPT_PROXY_14V( FuncName ) DEFINE_SCRIPT_PROXY_GUTS_NO_RETVAL( FuncName, 14 )
+
+//-----------------------------------------------------------------------------
+
+#include "tier0/memdbgoff.h"
+
+#endif // IVSCRIPT_H

--- a/public/vscript/ivscript.h
+++ b/public/vscript/ivscript.h
@@ -121,7 +121,7 @@ class CUtlBuffer;
 //
 //-----------------------------------------------------------------------------
 
-#define VSCRIPT_INTERFACE_VERSION		"VScriptManager009"
+#define VSCRIPT_INTERFACE_VERSION		"VScriptManager010"
 
 //-----------------------------------------------------------------------------
 //

--- a/public/vscript/ivscript.h
+++ b/public/vscript/ivscript.h
@@ -660,6 +660,7 @@ public:
 	// Scope
 	//--------------------------------------------------------
 	virtual HSCRIPT CreateScope( const char *pszScope, HSCRIPT hParent = NULL ) = 0;
+	virtual HSCRIPT ReferenceScope( HSCRIPT hScript ) = 0;
 	virtual void ReleaseScope( HSCRIPT hScript ) = 0;
 
 	//--------------------------------------------------------

--- a/public/vscript/vscript_templates.h
+++ b/public/vscript/vscript_templates.h
@@ -1,0 +1,414 @@
+//========== Copyright © 2008, Valve Corporation, All rights reserved. ========
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef VSCRIPT_TEMPLATES_H
+#define VSCRIPT_TEMPLATES_H
+
+#include "tier0/basetypes.h"
+
+#if defined( _WIN32 )
+#pragma once
+#endif
+
+#define	FUNC_APPEND_PARAMS_0	
+#define	FUNC_APPEND_PARAMS_1	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 1 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) );
+#define	FUNC_APPEND_PARAMS_2	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 2 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) );
+#define	FUNC_APPEND_PARAMS_3	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 3 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );
+#define	FUNC_APPEND_PARAMS_4	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 4 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) );
+#define	FUNC_APPEND_PARAMS_5	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 5 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) );
+#define	FUNC_APPEND_PARAMS_6	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 6 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) );
+#define	FUNC_APPEND_PARAMS_7	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 7 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) );
+#define	FUNC_APPEND_PARAMS_8	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 8 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) );
+#define	FUNC_APPEND_PARAMS_9	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 9 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) );
+#define	FUNC_APPEND_PARAMS_10	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 10 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_10 ) );
+#define	FUNC_APPEND_PARAMS_11	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 11 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_10 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_11 ) );
+#define	FUNC_APPEND_PARAMS_12	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 12 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_10 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_11 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_12 ) );
+#define	FUNC_APPEND_PARAMS_13	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 13 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_10 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_11 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_12 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_13 ) );
+#define	FUNC_APPEND_PARAMS_14	pDesc->m_Parameters.SetGrowSize( 1 ); pDesc->m_Parameters.EnsureCapacity( 14 ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_1 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_2 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_3 ) );	pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_4 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_5 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_6 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_7 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_8 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_9 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_10 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_11 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_12 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_13 ) ); pDesc->m_Parameters.AddToTail( ScriptDeduceType( FUNC_ARG_TYPE_14 ) );
+
+#define DEFINE_NONMEMBER_FUNC_TYPE_DEDUCER(N) \
+	template <typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	inline void ScriptDeduceFunctionSignature(ScriptFuncDescriptor_t *pDesc, FUNCTION_RETTYPE (*pfnProxied)( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) ) \
+	{ \
+		pDesc->m_ReturnType = ScriptDeduceType(FUNCTION_RETTYPE); \
+		FUNC_APPEND_PARAMS_##N \
+	}
+
+FUNC_GENERATE_ALL( DEFINE_NONMEMBER_FUNC_TYPE_DEDUCER );
+
+#define DEFINE_MEMBER_FUNC_TYPE_DEDUCER(N) \
+	template <typename OBJECT_TYPE_PTR, typename FUNCTION_CLASS, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	inline void ScriptDeduceFunctionSignature(ScriptFuncDescriptor_t *pDesc, OBJECT_TYPE_PTR pObject, FUNCTION_RETTYPE ( FUNCTION_CLASS::*pfnProxied )( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) ) \
+	{ \
+		pDesc->m_ReturnType = ScriptDeduceType(FUNCTION_RETTYPE); \
+		FUNC_APPEND_PARAMS_##N \
+	}
+
+FUNC_GENERATE_ALL( DEFINE_MEMBER_FUNC_TYPE_DEDUCER );
+
+//-------------------------------------
+
+#define DEFINE_CONST_MEMBER_FUNC_TYPE_DEDUCER(N) \
+	template <typename OBJECT_TYPE_PTR, typename FUNCTION_CLASS, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	inline void ScriptDeduceFunctionSignature(ScriptFuncDescriptor_t *pDesc, OBJECT_TYPE_PTR pObject, FUNCTION_RETTYPE ( FUNCTION_CLASS::*pfnProxied )( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) const ) \
+	{ \
+		pDesc->m_ReturnType = ScriptDeduceType(FUNCTION_RETTYPE); \
+		FUNC_APPEND_PARAMS_##N \
+	}
+
+FUNC_GENERATE_ALL( DEFINE_CONST_MEMBER_FUNC_TYPE_DEDUCER );
+
+#define ScriptInitMemberFuncDescriptor_( pDesc, class, func, scriptName )	if ( 0 ) {} else { (pDesc)->m_pszScriptName = scriptName; (pDesc)->m_pszFunction = #func; ScriptDeduceFunctionSignature( pDesc, (class *)(0), &class::func ); }
+
+#define ScriptInitFuncDescriptorNamed( pDesc, func, scriptName )						if ( 0 ) {} else { (pDesc)->m_pszScriptName = scriptName; (pDesc)->m_pszFunction = #func; ScriptDeduceFunctionSignature( pDesc, &func ); }
+#define ScriptInitFuncDescriptor( pDesc, func )											ScriptInitFuncDescriptorNamed( pDesc, func, #func )
+#define ScriptInitMemberFuncDescriptorNamed( pDesc, class, func, scriptName )			ScriptInitMemberFuncDescriptor_( pDesc, class, func, scriptName )
+#define ScriptInitMemberFuncDescriptor( pDesc, class, func )							ScriptInitMemberFuncDescriptorNamed( pDesc, class, func, #func )
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+template <typename FUNCPTR_TYPE>
+inline void *ScriptConvertFuncPtrToVoid( FUNCPTR_TYPE pFunc )
+{
+	if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) ) )
+	{
+		union FuncPtrConvert
+		{
+			void *p;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvert convert;
+		convert.pFunc = pFunc;
+		return convert.p;
+	}
+#if defined( COMPILER_MSVC )
+	else if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) + sizeof( int ) ) )
+	{
+		struct MicrosoftUnknownMFP
+		{
+			void *p;
+			int m_delta;
+		};
+	
+		union FuncPtrConvertMI
+		{
+			MicrosoftUnknownMFP mfp;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvertMI convert;
+		convert.pFunc = pFunc;
+		if ( convert.mfp.m_delta == 0 )
+		{
+			return convert.mfp.p;
+		}
+		AssertMsg( 0, "Function pointer must be from primary vtable" );
+	}
+	else if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) + ( sizeof( int ) * 3 ) ) )
+	{
+		struct MicrosoftUnknownMFP
+		{
+			void *p;
+			int m_delta;
+			int m_vtordisp;
+			int m_vtable_index;
+		};
+
+		union FuncPtrConvertMI
+		{
+			MicrosoftUnknownMFP mfp;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvertMI convert;
+		convert.pFunc = pFunc;
+		if ( convert.mfp.m_delta == 0 )
+		{
+			return convert.mfp.p;
+		}
+		AssertMsg( 0, "Function pointer must be from primary vtable" );
+	}
+#elif defined( GNUC )
+	else if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) + sizeof( int ) ) )
+	{
+		AssertMsg( 0, "Note: This path has not been verified yet. See comments below in #else case." );
+	
+		struct GnuMFP
+		{
+			union
+			{
+				void *funcadr;		// If vtable_index_2 is even, then this is the function pointer.
+				int vtable_index_2;		// If vtable_index_2 is odd, then this = vindex*2+1.
+			};
+			int delta;
+		};
+	
+		GnuMFP *p = (GnuMFP*)&pFunc;
+		if ( p->vtable_index_2 & 1 )
+		{
+			char **delta = (char**)p->delta;
+			char *pCur = *delta + (p->vtable_index_2+1)/2;
+			return (void*)( pCur + 4 );
+		}
+		else
+		{
+			return p->funcadr;
+		}
+	}
+#else
+#error "Need to implement code to crack non-offset member function pointer case"
+	// For gcc, see: http://www.codeproject.com/KB/cpp/FastDelegate.aspx
+	//
+	// Current versions of the GNU compiler use a strange and tricky 
+	// optimization. It observes that, for virtual inheritance, you have to look 
+	// up the vtable in order to get the voffset required to calculate the this 
+	// pointer. While you're doing that, you might as well store the function 
+	// pointer in the vtable. By doing this, they combine the m_func_address and 
+	// m_vtable_index fields into one, and they distinguish between them by 
+	// ensuring that function pointers always point to even addresses but vtable 
+	// indices are always odd:
+	// 
+	// 	// GNU g++ uses a tricky space optimisation, also adopted by IBM's VisualAge and XLC.
+	// 	struct GnuMFP {
+	// 	   union {
+	// 	     CODEPTR funcadr; // always even
+	// 	     int vtable_index_2; //  = vindex*2+1, always odd
+	// 	   };
+	// 	   int delta;
+	// 	};
+	// 	adjustedthis = this + delta
+	// 	if (funcadr & 1) CALL (* ( *delta + (vindex+1)/2) + 4)
+	// 	else CALL funcadr
+	// 
+	// The G++ method is well documented, so it has been adopted by many other 
+	// vendors, including IBM's VisualAge and XLC compilers, recent versions of 
+	// Open64, Pathscale EKO, and Metrowerks' 64-bit compilers. A simpler scheme 
+	// used by earlier versions of GCC is also very common. SGI's now 
+	// discontinued MIPSPro and Pro64 compilers, and Apple's ancient MrCpp 
+	// compiler used this method. (Note that the Pro64 compiler has become the 
+	// open source Open64 compiler).
+
+#endif
+	else
+		AssertMsg( 0, "Member function pointer not supported. Why on earth are you using virtual inheritance!?" );
+	return NULL;
+}
+
+template <typename FUNCPTR_TYPE>
+inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
+{
+	if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) ) )
+	{
+		union FuncPtrConvert
+		{
+			void *p;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvert convert;
+		convert.p = p;
+		return convert.pFunc;
+	}
+
+#if defined( COMPILER_MSVC )
+	if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) + sizeof( int ) ) )
+	{
+		struct MicrosoftUnknownMFP
+		{
+			void *p;
+			int m_delta;
+		};
+
+		union FuncPtrConvertMI
+		{
+			MicrosoftUnknownMFP mfp;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvertMI convert;
+		convert.mfp.p = p;
+		convert.mfp.m_delta = 0;
+		return convert.pFunc;
+	}
+	if ( ( sizeof( FUNCPTR_TYPE ) == sizeof( void * ) + ( sizeof( int ) * 3 ) ) )
+	{
+		struct MicrosoftUnknownMFP
+		{
+			void *p;
+			int m_delta;
+			int m_vtordisp;
+			int m_vtable_index;
+		};
+
+		union FuncPtrConvertMI
+		{
+			MicrosoftUnknownMFP mfp;
+			FUNCPTR_TYPE pFunc;
+		};
+
+		FuncPtrConvertMI convert;
+		convert.mfp.p = p;
+		convert.mfp.m_delta = 0;
+		return convert.pFunc;
+	}
+#elif defined( POSIX )
+	AssertMsg( 0, "Note: This path has not been implemented yet." );
+#else
+#error "Need to implement code to crack non-offset member function pointer case"
+#endif
+	Assert( 0 );
+	return NULL;
+}
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_0
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_1 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_1
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_2 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_2
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_3 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_3
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_4 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_4
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_5 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_5
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_6 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_6
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_7 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_7
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_8 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_8
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_9 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_9
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_10 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_10
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_11 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_11
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_12 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_12
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_13 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_13
+#define FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_14 , FUNC_BASE_TEMPLATE_FUNC_PARAMS_14
+
+#define	SCRIPT_BINDING_ARGS_0
+#define	SCRIPT_BINDING_ARGS_1 pArguments[0]
+#define	SCRIPT_BINDING_ARGS_2 pArguments[0], pArguments[1]
+#define	SCRIPT_BINDING_ARGS_3 pArguments[0], pArguments[1], pArguments[2]
+#define	SCRIPT_BINDING_ARGS_4 pArguments[0], pArguments[1], pArguments[2], pArguments[3]
+#define	SCRIPT_BINDING_ARGS_5 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4]
+#define	SCRIPT_BINDING_ARGS_6 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5]
+#define	SCRIPT_BINDING_ARGS_7 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6]
+#define	SCRIPT_BINDING_ARGS_8 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7]
+#define	SCRIPT_BINDING_ARGS_9 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8]
+#define	SCRIPT_BINDING_ARGS_10 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8], pArguments[9]
+#define	SCRIPT_BINDING_ARGS_11 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8], pArguments[9], pArguments[10]
+#define	SCRIPT_BINDING_ARGS_12 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8], pArguments[9], pArguments[10], pArguments[11]
+#define	SCRIPT_BINDING_ARGS_13 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8], pArguments[9], pArguments[10], pArguments[11], pArguments[12]
+#define	SCRIPT_BINDING_ARGS_14 pArguments[0], pArguments[1], pArguments[2], pArguments[3], pArguments[4], pArguments[5], pArguments[6], pArguments[7], pArguments[8], pArguments[9], pArguments[10], pArguments[11], pArguments[12], pArguments[13]
+
+
+#define DEFINE_SCRIPT_BINDINGS(N) \
+	template <typename FUNC_TYPE, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CNonMemberScriptBinding##N \
+	{ \
+	public: \
+ 		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+ 		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( !pContext ); \
+			\
+			if ( nArguments != N || !pReturn || pContext ) \
+			{ \
+				return false; \
+			} \
+			*pReturn = ((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ); \
+			if ( pReturn->m_type == FIELD_VECTOR ) \
+				pReturn->m_pVector = new Vector(*pReturn->m_pVector); \
+ 			return true; \
+ 		} \
+	}; \
+	\
+	template <typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CNonMemberScriptBinding##N<FUNC_TYPE, void FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( !pReturn ); \
+			Assert( !pContext ); \
+			\
+			if ( nArguments != N || pReturn || pContext ) \
+			{ \
+				return false; \
+			} \
+			((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ); \
+			return true; \
+		} \
+	}; \
+	\
+	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CMemberScriptBinding##N \
+	{ \
+	public: \
+ 		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+ 		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( pContext ); \
+			\
+			if ( nArguments != N || !pReturn || !pContext ) \
+			{ \
+				return false; \
+			} \
+			*pReturn = (((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ); \
+			if ( pReturn->m_type == FIELD_VECTOR ) \
+				pReturn->m_pVector = new Vector(*pReturn->m_pVector); \
+ 			return true; \
+ 		} \
+	}; \
+	\
+	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CMemberScriptBinding##N<OBJECT_TYPE_PTR, FUNC_TYPE, void FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( !pReturn ); \
+			Assert( pContext ); \
+			\
+			if ( nArguments != N || pReturn || !pContext ) \
+			{ \
+				return false; \
+			} \
+			(((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ); \
+			return true; \
+		} \
+	}; \
+	\
+	template <typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	inline ScriptBindingFunc_t ScriptCreateBinding(FUNCTION_RETTYPE (*pfnProxied)( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) ) \
+	{ \
+		typedef FUNCTION_RETTYPE (*Func_t)(FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N); \
+		return &CNonMemberScriptBinding##N<Func_t, FUNCTION_RETTYPE FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N>::Call; \
+	} \
+	\
+	template <typename OBJECT_TYPE_PTR, typename FUNCTION_CLASS, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+		inline ScriptBindingFunc_t ScriptCreateBinding(OBJECT_TYPE_PTR pObject, FUNCTION_RETTYPE (FUNCTION_CLASS::*pfnProxied)( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) ) \
+	{ \
+		typedef FUNCTION_RETTYPE (FUNCTION_CLASS::*Func_t)(FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N); \
+		return &CMemberScriptBinding##N<OBJECT_TYPE_PTR, Func_t, FUNCTION_RETTYPE FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N>::Call; \
+	} \
+	\
+	template <typename OBJECT_TYPE_PTR, typename FUNCTION_CLASS, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+		inline ScriptBindingFunc_t ScriptCreateBinding(OBJECT_TYPE_PTR pObject, FUNCTION_RETTYPE (FUNCTION_CLASS::*pfnProxied)( FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N ) const ) \
+	{ \
+		typedef FUNCTION_RETTYPE (FUNCTION_CLASS::*Func_t)(FUNC_BASE_TEMPLATE_FUNC_PARAMS_##N); \
+		return &CMemberScriptBinding##N<OBJECT_TYPE_PTR, Func_t, FUNCTION_RETTYPE FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N>::Call; \
+	}
+
+FUNC_GENERATE_ALL( DEFINE_SCRIPT_BINDINGS );
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+
+#endif // VSCRIPT_TEMPLATES_H


### PR DESCRIPTION
Closes #114

Adds vscript headers and their includes to the tf2 branch, copied from hl2sdk-csgo.

Also bumped `VSCRIPT_INTERFACE_VERSION` to `VScriptManager010`, current version for TF2.