### PR TITLE
fix(vscript): add unknown member to `ScriptFunctionBinding_t`

### DIFF
--- a/public/vscript/ivscript.h
+++ b/public/vscript/ivscript.h
@@ -1,4 +1,4 @@
-//========== Copyright © 2008, Valve Corporation, All rights reserved. ========
+//========== Copyright Â© 2008, Valve Corporation, All rights reserved. ========
 //
 // Purpose: VScript
 //
@@ -267,6 +267,8 @@ struct ScriptFunctionBinding_t
 	ScriptBindingFunc_t		m_pfnBinding;
 	void *					m_pFunction;
 	unsigned				m_flags;
+	
+	int                     m_unknown[3];
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Currently, SDK's `ScriptFunctionBinding_t` is size 0x30, while the disassembly has a m_FunctionBindings iteration size of 0x3c; this adds padding for correct vector iteration. Doesn't seem to be any references for the additional 3 bytes to be used anywhere yet.

I have not checked if this is present on other sdk branches w/ vscript.

```
pClass - 0xf17ad7e0

(gdb) p/ (char *)*(((*(0xf17ad7e0 + 0x10)) + (0x3c * 4)) + 0 )
$25 = 0xf1286926 "GetKeyFloat"
```