### PR TITLE
Sync IVDebugOverlay with current TF2 release

### DIFF
--- a/public/engine/ivdebugoverlay.h
+++ b/public/engine/ivdebugoverlay.h
@@ -39,6 +39,7 @@ public:
 	virtual void AddTextOverlay(const Vector& origin, float duration, const char *format, ...) = 0;
 	virtual void AddTextOverlay(const Vector& origin, int line_offset, float duration, const char *format, ...) = 0;
 	virtual void AddScreenTextOverlay(float flXPos, float flYPos,float flDuration, int r, int g, int b, int a, const char *text) = 0;
+	virtual void AddScreenTextOverlay(float flXPos, float flYPos, int line_offset, float flDuration, int r, int g, int b, int a, const char *text) = 0;
 	virtual void AddSweptBoxOverlay(const Vector& start, const Vector& end, const Vector& mins, const Vector& max, const QAngle & angles, int r, int g, int b, int a, float flDuration) = 0;
 	virtual void AddGridOverlay(const Vector& origin) = 0;
 	virtual int ScreenPosition(const Vector& point, Vector& screen) = 0;


### PR DESCRIPTION
TF2's VScript update appears to add a new member to the overlay interface.  Discovered by cross-checking `DebugOverlay003` interface argument counts / inferred types in disassembly on Windows binaries.

The existing `NDebugOverlay::ScreenText` call was affected by this change differently on Windows and Linux, so it suggests an overload.  The change seems to match the one present on `AddTextOverlay`.

Fixes [overlay-related functionality in RCBot2](https://github.com/nosoop/rcbot2/blob/6536e0e7c9d1c6d24b3320f5dc703c5b710dd6ac/utils/RCBot2_meta/bot_menu.cpp#L369-L385), as it relies on functions further down the list.  