### PR TITLE
Update the signature for IRecipientFilter::GetRecipientIndex

### DIFF
--- a/interfaces/interfaces.cpp
+++ b/interfaces/interfaces.cpp
@@ -102,6 +102,7 @@ IFlattenedSerializers *g_pFlattenedSerializers;
 ISource2Client *g_pSource2Client;
 ISource2ClientPrediction *g_pSource2ClientPrediction;
 ISource2Server *g_pSource2Server;
+ISource2ServerConfig *g_pSource2ServerConfig;
 ISource2ServerSerializers *g_pSource2ServerSerializers;
 ISource2Host *g_pSource2Host;
 ISource2GameClients *g_pSource2GameClients;
@@ -245,6 +246,7 @@ static const InterfaceGlobals_t g_pInterfaceGlobals[] =
 	{ SOURCE2CLIENT_INTERFACE_VERSION, &g_pSource2Client },
 	{ SOURCE2CLIENTPREDICTION_INTERFACE_VERSION, &g_pSource2ClientPrediction },
 	{ SOURCE2SERVER_INTERFACE_VERSION, &g_pSource2Server },
+	{ SOURCE2SERVERCONFIG_INTERFACE_VERSION, &g_pSource2ServerConfig },
 	{ SOURCE2SERVERSERIALIZERS_INTERFACE_VERSION, &g_pSource2ServerSerializers },
 	{ SOURCE2HOST_INTERFACE_VERSION, &g_pSource2Host },
 	{ SOURCE2GAMECLIENTS_INTERFACE_VERSION, &g_pSource2GameClients },

--- a/public/interfaces/interfaces.h
+++ b/public/interfaces/interfaces.h
@@ -224,6 +224,7 @@ class IFlattenedSerializers;
 class ISource2Client;
 class ISource2ClientPrediction;
 class ISource2Server;
+class ISource2ServerConfig;
 class ISource2ServerSerializers;
 class ISource2Host;
 class ISource2GameClients;
@@ -514,6 +515,9 @@ DECLARE_TIER3_INTERFACE( ISource2ClientPrediction, g_pSource2ClientPrediction );
 
 #define SOURCE2SERVER_INTERFACE_VERSION		"Source2Server001"
 DECLARE_TIER3_INTERFACE( ISource2Server, g_pSource2Server );
+
+#define SOURCE2SERVERCONFIG_INTERFACE_VERSION		"Source2ServerConfig001"
+DECLARE_TIER3_INTERFACE( ISource2ServerConfig, g_pSource2ServerConfig );
 
 #define SOURCE2SERVERSERIALIZERS_INTERFACE_VERSION		"Source2ServerSerializers001"
 DECLARE_TIER3_INTERFACE( ISource2ServerSerializers, g_pSource2ServerSerializers );

--- a/public/irecipientfilter.h
+++ b/public/irecipientfilter.h
@@ -25,7 +25,7 @@ public:
 	virtual bool	IsInitMessage( void ) const = 0;
 
 	virtual int		GetRecipientCount( void ) const = 0;
-	virtual CEntityIndex	GetRecipientIndex( int slot ) const = 0;
+	virtual CEntityIndex	*GetRecipientIndex( CEntityIndex *pEntIndex, int slot ) const = 0;
 };
 
 #endif // IRECIPIENTFILTER_H


### PR DESCRIPTION
I was trying to send a chat message to a specific player by slot using `UTIL_SayTextFilter` and discovered that the signature was incorrect which was quite problematic. Here's a decompilation:
```cpp
_DWORD *__fastcall CRecipientFilter::GetRecipientIndex(_QWORD *this, _DWORD *pEntIndex, int slot)
{
  __int64 v3; // rdi
  _DWORD *result; // rax

  v3 = slot;
  if ( slot < 0 || slot >= (*(*this + 24i64))(this) )
  {
    result = pEntIndex;
    *pEntIndex = -1;
  }
  else
  {
    result = pEntIndex;
    *pEntIndex = *(this[3] + 4 * v3);
  }
  return result;
}
```

In addition, I added the `Source2ServerConfig` interface.