### PR TITLE
Fix an abstract `CConCommandMemberAccessor<T>` error

### DIFF
--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -1088,7 +1088,7 @@ public:
 		m_pOwner = pOwner;
 	}
 
-	virtual void CommandCallback( const CCommand &command )
+	virtual void CommandCallback( const CCommandContext &context, const CCommand &command )
 	{
 		Assert( m_pOwner && m_Func );
 		(m_pOwner->*m_Func)( command );

--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -1065,7 +1065,7 @@ template< class T >
 class CConCommandMemberAccessor : public ConCommand, public ICommandCallback, public ICommandCompletionCallback
 {
 	typedef ConCommand BaseClass;
-	typedef void ( T::*FnMemberCommandCallback_t )( const CCommand &command );
+	typedef void ( T::*FnMemberCommandCallback_t )( const CCommandContext &context, const CCommand &command );
 	typedef int  ( T::*FnMemberCommandCompletionCallback_t )( const char *pPartial, CUtlVector< CUtlString > &commands );
 
 public:
@@ -1091,7 +1091,7 @@ public:
 	virtual void CommandCallback( const CCommandContext &context, const CCommand &command )
 	{
 		Assert( m_pOwner && m_Func );
-		(m_pOwner->*m_Func)( command );
+		(m_pOwner->*m_Func)( context, command );
 	}
 
 	virtual int  CommandCompletionCallback( const char *pPartial, CUtlVector< CUtlString > &commands )


### PR DESCRIPTION
When using `CON_COMMAND_MEMBER_F`, outputs: `error: field type 'CConCommandMemberAccessor<T>' is an abstract class`. This PR corrects this error