### PR TITLE
[CS:GO] Fix compilation errors for std=c++2a

### DIFF
--- a/public/mathlib/mathlib.h
+++ b/public/mathlib/mathlib.h
@@ -329,7 +329,7 @@ void inline SinCos( float radians, float *sine, float *cosine )
 		fstp DWORD PTR [eax]
 	}
 #elif defined( GNUC )
-	register double __cosr, __sinr;
+	double __cosr, __sinr;
  	__asm __volatile__ ("fsincos" : "=t" (__cosr), "=u" (__sinr) : "0" (radians));
 
   	*sine = __sinr;
@@ -628,11 +628,6 @@ template <class T> FORCEINLINE T AVG(T a, T b)
 
 // XYZ macro, for printf type functions - ex printf("%f %f %f",XYZ(myvector));
 #define XYZ(v) (v).x,(v).y,(v).z
-
-//
-// Returns a clamped value in the range [min, max].
-//
-#define clamp(val, min, max) (((val) > (max)) ? (max) : (((val) < (min)) ? (min) : (val)))
 
 inline float Sign( float x )
 {

--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -683,7 +683,7 @@ private:
 			return false;
 
 		ThreadMemoryBarrier();
-		++m_depth;
+		m_depth = m_depth + 1;
 		return true;
 	}
 
@@ -744,7 +744,7 @@ public:
 			DebuggerBreak();
 #endif
 
-		--m_depth;
+		m_depth = m_depth - 1;
 		if ( !m_depth )
 		{
 			ThreadMemoryBarrier();


### PR DESCRIPTION
The PR fixes these compilation errors:
- error: increment of object of volatile-qualified type 'volatile int' is deprecated
- error: ISO C++17 does not allow 'register' storage class specifier
- error: too many arguments provided to function-like macro invocation clamp

Explanation:
- Incrementing of a volatile type is deprecated but can be replaced with assignment of the incremented value.
- Register storage is not allowed, but it is just a hint and the keyword can be safely removed: https://stackoverflow.com/a/3207025/18259736
- The clamp macro is no longer required and can be excluded: https://www.mail-archive.com/pld-cvs-commit@lists.pld-linux.org/msg474109.html
