### PR TITLE
Remove not used include from IVehicle

### DIFF
--- a/game/shared/IVehicle.h
+++ b/game/shared/IVehicle.h
@@ -12,12 +12,13 @@
 #pragma once
 #endif
 
-#include "baseplayer_shared.h"
+#include "tier0/platform.h"
 
 class CUserCmd;
 class IMoveHelper;
 class CMoveData;
 class CBaseCombatCharacter;
+class CBasePlayer;
 
 // This is used by the player to access vehicles. It's an interface so the
 // vehicles are not restricted in what they can derive from.


### PR DESCRIPTION
The "baseplayer_shared.h" include goes with a lot of non-working code and can't be compiled.
As it is not required in IVehicle.h it can be removed.
The "platform.h" is still needed for the abstract_class key word.