### PR TITLE
IVEngineServer2 DisconnectClient

### DIFF
--- a/public/eiface.h
+++ b/public/eiface.h
@@ -322,9 +322,10 @@ public:
 	
 	virtual bool IsClientLowViolence( CEntityIndex clientIndex ) = 0;
 	
-#if 0 // Don't really match the binary
+	// Kicks the slot with the specified NetworkDisconnectionReason
 	virtual void DisconnectClient( CEntityIndex clientIndex, /* ENetworkDisconnectionReason */ int reason ) = 0;
-	
+
+#if 0 // Don't really match the binary
 	virtual void GetAllSpawnGroupsWithPVS( CUtlVector<SpawnGroupHandle_t> *spawnGroups, CUtlVector<IPVS *> *pOut ) = 0;
 	
 	virtual void P2PGroupChanged() = 0;
@@ -345,6 +346,7 @@ public:
     // Note that the internal reason is never displayed to the user.
 	//
 	// AM TODO: add header ref for ENetworkDisconnectReason from proto header
+	// AM TODO: ENetworkDisconnectionReason is ignored, always uses 41 (NETWORK_DISCONNECT_KICKBANADDED). Also, unlike DisconnectClient with reason 41, this also bans the client.
     virtual void KickClient( CPlayerSlot slot, const char *szInternalReason, /*ENetworkDisconnectionReason*/ char reason ) = 0;
 
 	virtual void unk015() = 0;

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -331,7 +331,6 @@ public:
 	virtual void P2PGroupChanged() = 0;
 #endif
 
-	virtual void unk006() = 0;
 	virtual void unk007() = 0;
 	virtual void unk008() = 0;
 	virtual void unk009() = 0;
@@ -342,12 +341,12 @@ public:
 
 	virtual void OnKickClient( const CCommandContext &context, const CCommand &cmd ) = 0;
 
-	// Kicks the slot with the specified NetworkDisconnectionReason.
+	// Kicks and bans the slot.
     // Note that the internal reason is never displayed to the user.
+	// ENetworkDisconnectionReason reason is ignored, client is always kicked with ENetworkDisconnectionReason::NETWORK_DISCONNECT_KICKBANADDED
 	//
 	// AM TODO: add header ref for ENetworkDisconnectReason from proto header
-	// AM TODO: ENetworkDisconnectionReason is ignored, always uses 41 (NETWORK_DISCONNECT_KICKBANADDED). Also, unlike DisconnectClient with reason 41, this also bans the client.
-    virtual void KickClient( CPlayerSlot slot, const char *szInternalReason, /*ENetworkDisconnectionReason*/ char reason ) = 0;
+    virtual void BanClient( CPlayerSlot slot, const char *szInternalReason, /*ENetworkDisconnectionReason*/ char reason ) = 0;
 
 	virtual void unk015() = 0;
 	virtual void unk016() = 0;


### PR DESCRIPTION
Tested with a metamod plugin and DisconnectClient works (and the reason is taken into account).

Thanks to `Pisex` for pointing out that DisconnectClient works.

I've also added a comment to the KickClient, as it acts more like BanClient. The client is always kicked with reason 41 (reason argument is ignored) and banned form the server. With DisconnectClient, even when using reason 41, the client only gets kicked.