### PR TITLE
Add vector normalization method

### DIFF
--- a/public/mathlib/vector.h
+++ b/public/mathlib/vector.h
@@ -129,6 +129,7 @@ public:
 	}
 
 	vec_t	NormalizeInPlace();
+	Vector	Normalized() const;
 	bool	IsLengthGreaterThan( float val ) const;
 	bool	IsLengthLessThan( float val ) const;
 
@@ -2218,6 +2219,13 @@ FORCEINLINE void VectorNormalizeFast( Vector &vec )
 inline vec_t Vector::NormalizeInPlace()
 {
 	return VectorNormalize( *this );
+}
+
+inline Vector Vector::Normalized() const
+{
+	Vector norm = *this;
+	VectorNormalize( norm );
+	return norm;
 }
 
 inline bool Vector::IsLengthGreaterThan( float val ) const


### PR DESCRIPTION
The implementation is taken from hl2sdk-csgo.

Vector::Normalized is present in:
- hl2sdk-blade
- hl2sdk-bms
- hl2sdk-csgo
- hl2sdk-doi
- hl2sdk-insurgency
- hl2sdk-pvkii
- hl2sdk-sdk2013

But missing in:
- hl2sdk-css
- hl2sdk-dods
- hl2sdk-episode1
- hl2sdk-hl2dm
- hl2sdk-l4d
- hl2sdk-l4d2
- hl2sdk-nucleardawn
- hl2sdk-orangebox
- hl2sdk-tf2

**Please, add it to all the branches where it is not present.**