### PR TITLE
Fix IEntityResourceManifest warning and EntitySpawnInfo_t size

### DIFF
--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -65,6 +65,7 @@ struct EntityDormancyChange_t : EntityNotification_t
 struct EntitySpawnInfo_t : EntityNotification_t
 {
 	const CEntityKeyValues* m_pKeyValues;
+	uint64_t unknown;
 };
 
 struct EntityActivation_t : EntityNotification_t

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -17,7 +17,7 @@ class IEntityPrecacheConfiguration;
 class IEntityResourceManifestBuilder;
 class ISpawnGroupEntityFilter;
 
-typedef void (*EntityResourceManifestCreationCallback_t)(struct IEntityResourceManifest*, void*);
+typedef void (*EntityResourceManifestCreationCallback_t)(IEntityResourceManifest *, void *);
 
 enum SpawnGroupEntityFilterType_t
 {

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -65,7 +65,7 @@ struct EntityDormancyChange_t : EntityNotification_t
 struct EntitySpawnInfo_t : EntityNotification_t
 {
 	const CEntityKeyValues* m_pKeyValues;
-	uint64_t unknown;
+	uint64 unknown;
 };
 
 struct EntityActivation_t : EntityNotification_t


### PR DESCRIPTION
EntitySpawnInfo_t should be 24 bytes, but currently is 16 bytes.