### PR TITLE
Update Collision_Group_t

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -355,7 +355,7 @@ enum RenderFx_t : unsigned char
 
 enum Collision_Group_t
 {
-	COLLISION_GROUP_NONE  = 0,
+	COLLISION_GROUP_NONE  = 4,
 	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world and static stuff
 	COLLISION_GROUP_DEBRIS_TRIGGER, // Same as debris, but hits triggers
 	COLLISION_GROUP_INTERACTIVE_DEBRIS,	// Collides with everything except other interactive debris or debris
@@ -381,7 +381,7 @@ enum Collision_Group_t
 
 
 
-	COLLISION_GROUP_DEBRIS_BLOCK_PROJECTILE, // Only collides with bullets
+	COLLISION_GROUP_PROPS,
 
 	LAST_SHARED_COLLISION_GROUP
 };

--- a/public/const.h
+++ b/public/const.h
@@ -355,11 +355,11 @@ enum RenderFx_t : unsigned char
 
 enum Collision_Group_t
 {
-	COLLISION_GROUP_UNKNOWN0 = 0,
+	COLLISION_GROUP_NONE = 0,
 	COLLISION_GROUP_UNKNOWN1,
 	COLLISION_GROUP_UNKNOWN2,
 	COLLISION_GROUP_UNKNOWN3,
-	COLLISION_GROUP_NONE,			// Also known as "Default"
+	COLLISION_GROUP_DEFAULT,
 	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world, static stuff and triggers
 	COLLISION_GROUP_INTERACTIVE_DEBRIS,	// Collides with everything except other interactive debris or debris
 	COLLISION_GROUP_INTERACTIVE,	// Collides with everything except interactive debris or debris

--- a/public/const.h
+++ b/public/const.h
@@ -355,7 +355,11 @@ enum RenderFx_t : unsigned char
 
 enum Collision_Group_t
 {
-	COLLISION_GROUP_NONE  = 4,
+	COLLISION_GROUP_UNKNOWN0 = 0,
+	COLLISION_GROUP_UNKNOWN1,
+	COLLISION_GROUP_UNKNOWN2,
+	COLLISION_GROUP_UNKNOWN3,
+	COLLISION_GROUP_NONE,			// Also known as "Default"
 	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world, static stuff and triggers
 	COLLISION_GROUP_INTERACTIVE_DEBRIS,	// Collides with everything except other interactive debris or debris
 	COLLISION_GROUP_INTERACTIVE,	// Collides with everything except interactive debris or debris

--- a/public/const.h
+++ b/public/const.h
@@ -356,8 +356,7 @@ enum RenderFx_t : unsigned char
 enum Collision_Group_t
 {
 	COLLISION_GROUP_NONE  = 4,
-	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world and static stuff
-	COLLISION_GROUP_DEBRIS_TRIGGER, // Same as debris, but hits triggers
+	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world, static stuff and triggers
 	COLLISION_GROUP_INTERACTIVE_DEBRIS,	// Collides with everything except other interactive debris or debris
 	COLLISION_GROUP_INTERACTIVE,	// Collides with everything except interactive debris or debris
 	COLLISION_GROUP_PLAYER,


### PR DESCRIPTION
Got it from vphysics dll, collision group 0-3 doesn't seem to exist...? Everything else is shifted by 4, and COLLISION_GROUP_NONE is also called "Default" in the dll.