### PR TITLE
Remove m_nAllocationCount, m_nGrowSize from CUtlRBTree

### DIFF
--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -287,9 +287,6 @@ protected:
 	I m_FirstFree;
 	typename M::Iterator_t m_LastAlloc; // the last index allocated
 
-	int m_nAllocationCount;
-	int m_nGrowSize;
-
 	FORCEINLINE M const &Elements( void ) const
 	{
 		return m_Elements;


### PR DESCRIPTION
Found while searching for the cause of a CUtlDict size mismatch