### PR TITLE
Update CGameEntitySystem

### DIFF
--- a/entity2/entitysystem.cpp
+++ b/entity2/entitysystem.cpp
@@ -38,3 +38,16 @@ CBaseEntity* CEntitySystem::GetBaseEntity(const CEntityHandle& hEnt)
 
 	return dynamic_cast<CBaseEntity*>(pIdentity->m_pInstance);
 }
+
+void CGameEntitySystem::AddListenerEntity(IEntityListener* pListener)
+{
+	if (m_entityListeners.Find(pListener) == -1)
+	{
+		m_entityListeners.AddToTail(pListener);
+	}
+}
+
+void CGameEntitySystem::RemoveListenerEntity(IEntityListener* pListener)
+{
+	m_entityListeners.FindAndRemove(pListener);
+}

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -92,9 +92,10 @@ struct CEntityPrecacheContext
 class IEntityListener
 {
 public:
-	virtual void OnEntityCreated(CBaseEntity* pEntity) {};
-	virtual void OnEntitySpawned(CBaseEntity* pEntity) {};
-	virtual void OnEntityDeleted(CBaseEntity* pEntity) {};
+	virtual void OnEntityCreated(CEntityInstance* pEntity) {};
+	virtual void OnEntitySpawned(CEntityInstance* pEntity) {};
+	virtual void OnEntityDeleted(CEntityInstance* pEntity) {};
+	virtual void OnEntityParentChanged(CEntityInstance* pEntity, CEntityInstance* pNewParent) {};
 };
 
 struct CEntityResourceManifestLock
@@ -124,7 +125,7 @@ public:
 };
 
 
-// Size: 0x1510 (from constructor)
+// Size: 0x1510 | 0x1540 (from constructor)
 class CEntitySystem : public IEntityResourceManifestBuilder
 {
 public:
@@ -153,9 +154,12 @@ public:
 	// CConcreteEntityList seems to be correct but m_CallQueue supposedly starts at offset 2664, which is... impossible?
 	// Based on CEntitySystem::CEntitySystem found via string "MaxNonNetworkableEntities"
 	uint8 unk2696[0xa88];
+#ifdef __linux__
+	uint8 unk5392[0x30];
+#endif
 };
 
-// Size: 0x1580 (from constructor)
+// Size: 0x1580 | 0x15B0 (from constructor)
 class CGameEntitySystem : public CEntitySystem
 {
 	struct SpawnGroupEntityFilterInfo_t
@@ -165,18 +169,17 @@ class CGameEntitySystem : public CEntitySystem
 	};
 	//typedef SpawnGroupEntityFilterInfo_t CUtlMap<char const*, SpawnGroupEntityFilterInfo_t, int, bool (*)(char const* const&, char const* const&)>::ElemType_t;
 
-
 public:
 	virtual				~CGameEntitySystem() = 0;
 
 public:
-	int m_iMaxNetworkedEntIndex;
-	int m_iNetworkedEntCount;
-	int m_iNonNetworkedSavedEntCount;
+	int m_iMaxNetworkedEntIndex; // 5392 | 5440
+	int m_iNetworkedEntCount; // 5396 | 5444
+	int m_iNonNetworkedSavedEntCount; // 5400 | 5448
 	// int m_iNumEdicts; // This is no longer referenced in the server binary
-	CUtlDict<CGameEntitySystem::SpawnGroupEntityFilterInfo_t, int> m_spawnGroupEntityFilters;
-	CUtlVector<IEntityListener*, CUtlMemory<IEntityListener*, int> > m_entityListeners;
-	uint8 unk5480[0x18];
+	CUtlDict<CGameEntitySystem::SpawnGroupEntityFilterInfo_t> m_spawnGroupEntityFilters; // 5408 | 5456
+	CUtlVector<IEntityListener*> m_entityListeners; // 5448 | 5496
+	uint8 unk5480[0x20];
 };
 
 #endif // ENTITYSYSTEM_H

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -65,7 +65,7 @@ struct EntityDormancyChange_t : EntityNotification_t
 struct EntitySpawnInfo_t : EntityNotification_t
 {
 	const CEntityKeyValues* m_pKeyValues;
-	uint64 unknown;
+	uint64 m_Unk1;
 };
 
 struct EntityActivation_t : EntityNotification_t
@@ -80,7 +80,6 @@ struct PostDataUpdateInfo_t : EntityNotification_t
 {
 	DataUpdateType_t m_updateType;
 };
-
 
 struct CEntityPrecacheContext
 {
@@ -124,7 +123,6 @@ public:
 	virtual void		LockResourceManifest(bool bLock, CEntityResourceManifestLock* const context) = 0;
 };
 
-
 // Size: 0x1510 | 0x1540 (from constructor)
 class CEntitySystem : public IEntityResourceManifestBuilder
 {
@@ -153,9 +151,11 @@ public:
 	CConcreteEntityList m_EntityList;
 	// CConcreteEntityList seems to be correct but m_CallQueue supposedly starts at offset 2664, which is... impossible?
 	// Based on CEntitySystem::CEntitySystem found via string "MaxNonNetworkableEntities"
-	uint8 unk2696[0xa88];
+
+private:
+	uint8 pad2696[0xa88];
 #ifdef PLATFORM_LINUX
-	uint8 unk5392[0x30];
+	uint8 pad5392[0x30];
 #endif
 };
 
@@ -180,9 +180,11 @@ public:
 	int m_iNetworkedEntCount; // 5396 | 5444
 	int m_iNonNetworkedSavedEntCount; // 5400 | 5448
 	// int m_iNumEdicts; // This is no longer referenced in the server binary
-	CUtlDict<CGameEntitySystem::SpawnGroupEntityFilterInfo_t> m_spawnGroupEntityFilters; // 5408 | 5456
+	CUtlDict<SpawnGroupEntityFilterInfo_t> m_spawnGroupEntityFilters; // 5408 | 5456
 	CUtlVector<IEntityListener*> m_entityListeners; // 5448 | 5496
-	uint8 unk5480[0x20];
+
+private:
+	uint8 pad5480[0x20];
 };
 
 #endif // ENTITYSYSTEM_H

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -154,7 +154,7 @@ public:
 	// CConcreteEntityList seems to be correct but m_CallQueue supposedly starts at offset 2664, which is... impossible?
 	// Based on CEntitySystem::CEntitySystem found via string "MaxNonNetworkableEntities"
 	uint8 unk2696[0xa88];
-#ifdef __linux__
+#ifdef PLATFORM_LINUX
 	uint8 unk5392[0x30];
 #endif
 };

--- a/public/entity2/entitysystem.h
+++ b/public/entity2/entitysystem.h
@@ -172,6 +172,9 @@ class CGameEntitySystem : public CEntitySystem
 public:
 	virtual				~CGameEntitySystem() = 0;
 
+	void AddListenerEntity(IEntityListener* pListener);
+	void RemoveListenerEntity(IEntityListener* pListener);
+
 public:
 	int m_iMaxNetworkedEntIndex; // 5392 | 5440
 	int m_iNetworkedEntCount; // 5396 | 5444


### PR DESCRIPTION
Fixed CEntitySystem size for linux, corrected CGameEntitySystem due to incorrectly sized CUtlDict, added missing function in IEntityListener