### PR TITLE
Update CCheckTransmitInfo

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -58,7 +58,7 @@
 #define SP_MODEL_INDEX_BITS			11
 
 // How many bits to use to encode an edict.
-#define	MAX_EDICT_BITS				11			// # of bits needed to represent max edicts
+#define	MAX_EDICT_BITS				14			// # of bits needed to represent max edicts
 // Max # of edicts in a level
 #define	MAX_EDICTS					(1<<MAX_EDICT_BITS)
 

--- a/public/iservernetworkable.h
+++ b/public/iservernetworkable.h
@@ -37,21 +37,10 @@ class CBaseNetworkable;
 class CCheckTransmitInfo
 {
 public:
-	edict_t	*m_pClientEnt;	// pointer to receiver edict
-	byte	m_PVS[PAD_NUMBER( MAX_MAP_CLUSTERS,8 ) / 8];
-	int		m_nPVSSize;		// PVS size in bytes
-
-	CBitVec<MAX_EDICTS>	*m_pTransmitEdict;	// entity n is already marked for transmission
+	CBitVec<MAX_EDICTS>	*m_pTransmitEntity;	// entity n is already marked for transmission
 	CBitVec<MAX_EDICTS>	*m_pTransmitAlways; // entity n is always send even if not in PVS (HLTV and Replay only)
-	
-	int 	m_AreasNetworked; // number of networked areas 
-	int		m_Areas[MAX_WORLD_AREAS]; // the areas
-	
-	// This is used to determine visibility, so if the previous state
-	// is the same as the current state (along with pvs and areas networked),
-	// then the parts of the map that the player can see haven't changed.
-	byte	m_AreaFloodNums[MAX_MAP_AREAS];
-	int		m_nMapAreas;
+
+	// TODO: This is incomplete and may require further reversing in the future.
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
There are most likely more members beyond `m_pTransmitAlways` but I couldn't figure them out and they aren't important to us at the moment anyway. The old ones are definitely wrong though, areas are a BSP thing from source1.

In addition, `MAX_EDICT_BITS` was updated to reflect the source2 networked entity limit.