### PR TITLE
Add a missing return in utlsymbollarge.h

### DIFF
--- a/public/tier1/utlsymbollarge.h
+++ b/public/tier1/utlsymbollarge.h
@@ -1,4 +1,4 @@
-//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright ? 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: Defines a large symbol table (intp sized handles, can store more than 64k strings)
 //
@@ -183,7 +183,7 @@ private:
 		{
 			CUtlSymbolTableLargeBase* pTable = (CUtlSymbolTableLargeBase*)((uintptr_t)this + m_tableOffset);
 
-			pTable->HashValue( k );
+			return pTable->HashValue( k );
 		}
 	};
 


### PR DESCRIPTION
Addresses

```
In file included from /work/vendor/hl2sdk/public/entity2/entityinstance.h:7,
                 from /work/vendor/hl2sdk/public/iserverunknown.h:16,
                 from /work/vendor/hl2sdk/public/iserverentity.h:15,
                 from /work/vendor/hl2sdk/public/edict.h:17,
                 from /work/vendor/hl2sdk/public/eiface.h:18,
                 from /work/vendor/metamod-source/core/metamod.h:35,
                 from /work/vendor/metamod-source/core/gamedll_bridge.cpp:27:
/work/vendor/hl2sdk/public/tier1/utlsymbollarge.h: In member function ‘unsigned int CUtlSymbolTableLargeBase<MutexType, CASEINSENSITIVE>::UtlSymTableLargeHashFunctor::operator()(UtlSymLargeId_t) const’:
/work/vendor/hl2sdk/public/tier1/utlsymbollarge.h:187:3: error: no return statement in function returning non-void [-Werror=return-type]
  187 |   }
      |   ^
cc1plus: all warnings being treated as errors
```

On `g++-12`

Sorry, the diff is really long because the newlines got fucked up and I don't know how to preserve them.