### PR TITLE
Fix incorrect userid type

### DIFF
--- a/public/eiface.h
+++ b/public/eiface.h
@@ -126,7 +126,7 @@ public:
 	bool operator!=( const CPlayerUserId &other ) const { return other._index != _index; }
 
 private:
-	short _index;
+	unsigned short _index;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In CS2 the userid is an unsigned short, sometimes the userid will go up to values like 65280 which will currently get misinterpreted as a negative value.