### PR TITLE
Update missing collision group names

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -355,10 +355,10 @@ enum RenderFx_t : unsigned char
 
 enum Collision_Group_t
 {
-	COLLISION_GROUP_NONE = 0,
-	COLLISION_GROUP_UNKNOWN1,
-	COLLISION_GROUP_UNKNOWN2,
-	COLLISION_GROUP_UNKNOWN3,
+	COLLISION_GROUP_ALWAYS = 0,
+	COLLISION_GROUP_NEVER,
+	COLLISION_GROUP_TRIGGER,
+	COLLISION_GROUP_CONDITIONALLY_SOLID,
 	COLLISION_GROUP_DEFAULT,
 	COLLISION_GROUP_DEBRIS,			// Collides with nothing but world, static stuff and triggers
 	COLLISION_GROUP_INTERACTIVE_DEBRIS,	// Collides with everything except other interactive debris or debris


### PR DESCRIPTION
Found from vphysics2.dll and `phys_debug_draw` concommand output