### PR TITLE
Swap IGameEvent Set overloads

### DIFF
--- a/public/igameevents.h
+++ b/public/igameevents.h
@@ -123,10 +123,10 @@ public:
 	virtual void SetEntity( const GameEventKeySymbol_t &keySymbol, CEntityIndex value ) = 0;
 	virtual void SetEntity( const GameEventKeySymbol_t &keySymbol, CEntityInstance *value ) = 0;
 
-	// Also sets the _pawn key
-	virtual void SetPlayer( const GameEventKeySymbol_t &keySymbol, CPlayerSlot value ) = 0;
 	// Also sets the _pawn key (Expects pawn entity to be passed)
 	virtual void SetPlayer( const GameEventKeySymbol_t &keySymbol, CEntityInstance *pawn ) = 0;
+	// Also sets the _pawn key
+	virtual void SetPlayer( const GameEventKeySymbol_t &keySymbol, CPlayerSlot value ) = 0;
 
 	// Expects pawn entity to be passed, will set the controller entity as a controllerKeyName
 	// and pawn entity as a pawnKeyName.

--- a/public/igameevents.h
+++ b/public/igameevents.h
@@ -119,9 +119,9 @@ public:
 	virtual void SetFloat( const GameEventKeySymbol_t &keySymbol, float value ) = 0;
 	virtual void SetString( const GameEventKeySymbol_t &keySymbol, const char *value ) = 0;
 	virtual void SetPtr( const GameEventKeySymbol_t &keySymbol, void *value ) = 0;
-
+	
+	virtual void SetEntity(const GameEventKeySymbol_t &keySymbol, CEntityInstance *value) = 0;
 	virtual void SetEntity( const GameEventKeySymbol_t &keySymbol, CEntityIndex value ) = 0;
-	virtual void SetEntity( const GameEventKeySymbol_t &keySymbol, CEntityInstance *value ) = 0;
 
 	// Also sets the _pawn key (Expects pawn entity to be passed)
 	virtual void SetPlayer( const GameEventKeySymbol_t &keySymbol, CEntityInstance *pawn ) = 0;


### PR DESCRIPTION
I stepped through this in a debugger and it did seem that the wrong function was called, and surely enough, they were supposed to be swapped. [This horrible hack](https://github.com/Source2ZE/CS2Fixes/blob/979d2e758965e28779969dd06510a1c52108aad1/src/zombiereborn.cpp#L230) was a workaround we used to set the player from a slot.