### PR TITLE
Update ISource2GameClients's ProcessUsercmds

### DIFF
--- a/public/eiface.h
+++ b/public/eiface.h
@@ -574,7 +574,7 @@ public:
 	virtual void			ClientSetupVisibility( CPlayerSlot slot, vis_info_t *visinfo ) = 0;
 
 	// A block of CUserCmds has arrived from the user, decode them and buffer for execution during player simulation
-	virtual float			ProcessUsercmds( CPlayerSlot slot, bf_read *buf, int numcmds, bool ignore, bool paused ) = 0;
+	virtual int			ProcessUsercmds( CPlayerSlot slot, bf_read *buf, int numcmds, bool ignore, bool paused ) = 0;
 
 	virtual bool			IsPlayerSlotOccupied( CPlayerSlot slot ) = 0;
 


### PR DESCRIPTION
Getting the result value on the post hook of `ProcessUsercmds` suggests that the value returned is an integer type and not a float.