### PR TITLE
Update linux IFileSystem

### DIFF
--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -559,7 +559,7 @@ public:
 	virtual bool			IsOk( FileHandle_t file ) = 0;
 
 	virtual bool			EndOfFile( FileHandle_t file ) = 0;
-#ifdef _WIN32
+#ifdef PLATFORM_WINDOWS
 	virtual CUtlString		ReadLine(FileHandle_t file, bool bStripNewline = true) = 0;
 #endif
 	virtual char			*ReadLine( char *pOutput, int maxChars, FileHandle_t file ) = 0;

--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -559,8 +559,9 @@ public:
 	virtual bool			IsOk( FileHandle_t file ) = 0;
 
 	virtual bool			EndOfFile( FileHandle_t file ) = 0;
-
-	virtual const char		*ReadLine(FileHandle_t file, bool bStripNewline = true) = 0;
+#ifdef _WIN32
+	virtual CUtlString		ReadLine(FileHandle_t file, bool bStripNewline = true) = 0;
+#endif
 	virtual char			*ReadLine( char *pOutput, int maxChars, FileHandle_t file ) = 0;
 
 	virtual int				FPrintf( FileHandle_t file, const char *pFormat, ... ) FMTFUNCTION( 3, 4 ) = 0;


### PR DESCRIPTION
The function doesn't seem to exist on Linux, and as stated by Didrole, its return type is a CUtlString allocated by the caller and passed as a hidden argument.