### PR TITLE
Update globalvars_base.h

### DIFF
--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -77,8 +77,8 @@ public:
 
 	// Simulation ticks - does not increase when game is paused
 	int tickcount;
-	// Simulation tick interval
-	float interval_per_tick;
+
+	float m_flSubtickFraction;
 };
 
 inline CGlobalVarsBase::CGlobalVarsBase()

--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -77,7 +77,7 @@ public:
 
 	// Simulation ticks - does not increase when game is paused
 	int tickcount;
-
+	// Non-zero when during movement processing, it's the part after the decimal point of the "when" field in player's subtick moves.
 	float m_flSubtickFraction;
 };
 


### PR DESCRIPTION
Call to Arms update no longer has interval_per_tick variable, since it's hardcoded into the game now. Instead it now has `m_flSubtickFraction`, which is set to non 0 when during movement processing, and its value being the part after the decimal point of the `when` field in player's subtick moves.