### PR TITLE
Fix IFileSystem vtable

### DIFF
--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -425,8 +425,8 @@ public:
 
 	virtual void			Seek(FileHandle_t file, int pos, FileSystemSeek_t seekType) = 0;
 	virtual unsigned int	Tell(FileHandle_t file) = 0;
-	virtual unsigned int	Size(const char *pFileName, const char *pPathID = 0) = 0;
 	virtual unsigned int	Size(FileHandle_t file) = 0;
+	virtual unsigned int	Size(const char *pFileName, const char *pPathID = 0) = 0;
 
 	virtual void			Flush(FileHandle_t file) = 0;
 	virtual bool			Precache(const char *pFileName, const char *pPathID = 0) = 0;


### PR DESCRIPTION
It seems the order for the overloads of IFileSystem::Size() has changed.