### PR TITLE
fix: error with V_swap

### DIFF
--- a/public/tier1/utlmemory.h
+++ b/public/tier1/utlmemory.h
@@ -1,4 +1,4 @@
-//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//===== Copyright ï¿½ 1996-2005, Valve Corporation, All rights reserved. ======//
 //
 // Purpose: 
 //
@@ -20,6 +20,7 @@
 
 #include "tier0/memalloc.h"
 #include "tier0/memdbgon.h"
+#include "mathlib/mathlib.h"
 
 #ifdef _MSC_VER
 #pragma warning (disable:4100)


### PR DESCRIPTION
`there are no arguments to ‘V_swap’ that depend on a template parameter, so a declaration of ‘V_swap’ must be available`

stumbled upon this when trying to compile an extension, not sure it's the best fix but it seemed simple enough