### PR TITLE
suppress: warning in initializing CThreadSpinRWLock

### DIFF
--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -1127,7 +1127,12 @@ private:
 class ALIGN8 PLATFORM_CLASS CThreadSpinRWLock
 {
 public:
-	CThreadSpinRWLock()	{ COMPILE_TIME_ASSERT( sizeof( LockInfo_t ) == sizeof( int64 ) ); Assert( (intp)this % 8 == 0 ); memset( this, 0, sizeof( *this ) ); }
+
+	CThreadSpinRWLock() : m_lockInfo{ 0, 0 }
+    {
+        COMPILE_TIME_ASSERT(sizeof(LockInfo_t) == sizeof(int64));
+        Assert((intp)this % 8 == 0);
+    }
 
 	bool TryLockForWrite();
 	bool TryLockForRead();


### PR DESCRIPTION
void* memset(void*, int, size_t)’ clearing an object of type ‘class CThreadSpinRWLock’ with no trivial copy-assignment; use value-initialization instead