### PR TITLE
Update player flags

### DIFF
--- a/public/const.h
+++ b/public/const.h
@@ -105,7 +105,7 @@
 #define	FL_ONGROUND				(1<<0)	// At rest / on the ground
 #define FL_DUCKING				(1<<1)	// Player flag -- Player is fully crouched
 #define	FL_WATERJUMP			(1<<2)	// player jumping out of water
-#define FL_NOCLIP				(1<<3)
+#define FL_NOCLIP				(1<<3) // Forces MOVETYPE_NOCLIP on the entity
 #define FL_FAKECLIENT			(1<<4)	// Fake client, simulated server side; don't send network messages to them
 #define FL_FROZEN				(1<<5) // Player is frozen for 3rd person camera
 #define FL_ATCONTROLS			(1<<6) // Player can't move, but keeps key inputs for controlling another entity

--- a/public/const.h
+++ b/public/const.h
@@ -105,12 +105,12 @@
 #define	FL_ONGROUND				(1<<0)	// At rest / on the ground
 #define FL_DUCKING				(1<<1)	// Player flag -- Player is fully crouched
 #define	FL_WATERJUMP			(1<<2)	// player jumping out of water
-#define FL_ONTRAIN				(1<<3) // Player is _controlling_ a train, so movement commands should be ignored on client during prediction.
-#define FL_INRAIN				(1<<4)	// Indicates the entity is standing in rain
+#define FL_NOCLIP				(1<<3)
+#define FL_FAKECLIENT			(1<<4)	// Fake client, simulated server side; don't send network messages to them
 #define FL_FROZEN				(1<<5) // Player is frozen for 3rd person camera
 #define FL_ATCONTROLS			(1<<6) // Player can't move, but keeps key inputs for controlling another entity
 #define	FL_CLIENT				(1<<7)	// Is a player
-#define FL_FAKECLIENT			(1<<8)	// Fake client, simulated server side; don't send network messages to them
+
 #define	FL_INWATER				(1<<9)	// In water
 
 // NOTE if you move things up, make sure to change this value


### PR DESCRIPTION
(1<<3) is now used for the `noclip` command.
(1<<4) is the flag checked by `IsBot` function inside movement code, though checking for a lack of `FL_CLIENT` flag seems to be the preferred way most of the time.