### PR TITLE
add memdbgon to utlleanvector

### DIFF
--- a/public/tier1/utlleanvector.h
+++ b/public/tier1/utlleanvector.h
@@ -20,6 +20,8 @@
 
 #include <limits>
 
+#include "tier0/memdbgon.h"
+
 #define FOR_EACH_LEANVEC( vecName, iteratorName ) \
 	for ( auto iteratorName = vecName.First(); vecName.IsValidIterator( iteratorName ); iteratorName = vecName.Next( iteratorName ) )
 
@@ -734,5 +736,7 @@ using CUtlLeanVector = CUtlLeanVectorImpl< CUtlLeanVectorBase< T, I >, T, I >;
 
 template < class T, size_t N = 3, class I = short >
 using CUtlLeanVectorFixedGrowable = CUtlLeanVectorImpl< CUtlLeanVectorFixedGrowableBase< T, N, I >, T, I >;
+
+#include "tier0/memdbgoff.h"
 
 #endif // UTLLEANVECTOR_H


### PR DESCRIPTION
utlleanvector.h uses realloc() in its EnsureCapacity, on windows realloc is overidden by memoverride however on linux it is not and it relies on memdbgon to override it, it missing in the header causes a crash whenever growing a CUtlLeanVector written to by the game, this PR fixes that.