### PR TITLE
Update IRecipientFilter and NetChannelBufType_t

### DIFF
--- a/public/inetchannel.h
+++ b/public/inetchannel.h
@@ -49,10 +49,11 @@ struct NetPacket_t
 };
 #endif // NET_PACKET_ST_DEFINED
 
-enum NetChannelBufType_t
+enum NetChannelBufType_t : int8
 {
-	BUF_RELIABLE = 0,
-	BUF_UNRELIABLE,
+	BUF_DEFAULT = -1,
+	BUF_UNRELIABLE = 0,
+	BUF_RELIABLE,
 	BUF_VOICE,
 };
 

--- a/public/irecipientfilter.h
+++ b/public/irecipientfilter.h
@@ -12,6 +12,7 @@
 #endif
 
 #include "eiface.h"
+#include "inetchannel.h"
 
 //-----------------------------------------------------------------------------
 // Purpose: Generic interface for routing messages to users
@@ -21,10 +22,10 @@ class IRecipientFilter
 public:
 	virtual			~IRecipientFilter() {}
 
-	virtual bool	IsReliable( void ) const = 0;
+	virtual NetChannelBufType_t	GetNetworkBufType( void ) const = 0;
 	virtual bool	IsInitMessage( void ) const = 0;
 
-	virtual int		GetRecipientCount( void ) const = 0;
+	virtual int 	GetRecipientCount( void ) const = 0;
 	virtual CPlayerSlot	GetRecipientIndex( int slot ) const = 0;
 };
 


### PR DESCRIPTION
```IRecipientFilter::IsReliable``` is actually ```IRecipientFilter::GetNetworkBufType```

```CSosCopyRecipientFilter::GetNetworkBufType```:
![img1](https://github.com/alliedmodders/hl2sdk/assets/152704532/8a426ed6-5c5b-4e06-97ad-3d35560b263d)

```IGameEventSystem::PostEventAbstract```:
![img2](https://github.com/alliedmodders/hl2sdk/assets/152704532/1ed25594-5f37-4922-9907-fa778a4e0623)

also ```NetChannelBufType_t``` requires reordering

```INetChannel::SendData```:
![img3](https://github.com/alliedmodders/hl2sdk/assets/152704532/a015e551-9281-4de9-a95c-29e5001db925)
