### PR TITLE
rename ISource2GameClients::GetPlayerScore

### DIFF
--- a/public/eiface.h
+++ b/public/eiface.h
@@ -584,7 +584,7 @@ public:
 
 	virtual bool			IsPlayerAlive( CPlayerSlot slot) = 0;
 
-	virtual int				GetPlayerScore( CPlayerSlot slot ) = 0;
+	virtual int				GetPlayerFrags( CPlayerSlot slot ) = 0;
 
 	// Get the ear position for a specified client
 	virtual void			ClientEarPosition( CPlayerSlot slot, Vector *pEarOrigin ) = 0;


### PR DESCRIPTION
Changed ISource2GameClients::GetPlayerScore to ISource2GameClients::GetPlayerFrags since it actually returns PlayerFrags