### PR TITLE
Update UtlStringMap.h to be compatible with c++20

### DIFF
--- a/public/tier1/UtlStringMap.h
+++ b/public/tier1/UtlStringMap.h
@@ -49,7 +49,7 @@ public:
 
 	bool Defined( const char *pString ) const
 	{
-		return m_SymbolTable.Find( pString ) != UTL_INVAL_SYMBOL;
+		return m_SymbolTable.Find( pString ).IsValid();
 	}
 
 	UtlSymId_t Find( const char *pString ) const


### PR DESCRIPTION
UtlStringMap.h:52:40: error: use of overloaded operator '!=' is ambiguous (with operand types 'CUtlSymbol' and 'UtlSymId_t' (aka 'unsigned short'))