### PR TITLE
Enable `tier0/threadtools.h` to compile under GCC with `-std=c++20`

### DIFF
--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -784,7 +784,7 @@ private:
 	MUTEX_TYPE &m_lock;
 
 	// Disallow copying
-	CAutoLockT<MUTEX_TYPE>( const CAutoLockT<MUTEX_TYPE> & );
+	CAutoLockT( const CAutoLockT<MUTEX_TYPE> & );
 	CAutoLockT<MUTEX_TYPE> &operator=( const CAutoLockT<MUTEX_TYPE> & );
 };
 


### PR DESCRIPTION
GCC won't compile this with `-std=c++20`:
```c++
template<class TBar>
class Foo
{
    // Note: Template parameter re-declaration in the copy constructor
    Foo<TBar>(const Foo<TBar>&);
};
```

...which is the syntax seen in `tier0/threadtools.h`. Although the AMBuild doesn't use C++20, I do -- and this change is rather simple, and correct anyhow.