### PR TITLE
Update CEntityInstance, remove IConnectionlessPacketHandler inheritance from INetworkGameServer

### DIFF
--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -49,6 +49,7 @@ public:
 	virtual void OnSave() = 0;
 	virtual void OnRestore() = 0;
 	
+	virtual void unk001() = 0;
 	virtual int ObjectCaps() = 0;
 	virtual CEntityIndex RequiredEdictIndex() = 0;
 	

--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -69,16 +69,16 @@ public:
 	
 	virtual void LogFieldInfo( const char* pszFieldName, const char* pszInfo ) = 0;
 	virtual bool FullEdictChanged() = 0;
-	virtual void unk001() = 0;
+	virtual void unk101() = 0;
 	virtual ChangeAccessorFieldPathIndex_t AddChangeAccessorPath( const CFieldPath& path ) = 0;
 	virtual void AssignChangeAccessorPathIds() = 0;
 	virtual ChangeAccessorFieldPathIndexInfo_t* GetChangeAccessorPathInfo_1() = 0;
 	virtual ChangeAccessorFieldPathIndexInfo_t* GetChangeAccessorPathInfo_2() = 0;
 	
-	virtual void unk101() = 0;
+	virtual void unk201() = 0;
 	virtual void ReloadPrivateScripts() = 0;
 	virtual datamap_t* GetDataDescMap() = 0;
-	virtual void unk201() = 0;
+	virtual void unk301() = 0;
 	virtual SchemaMetaInfoHandle_t<CSchemaClassInfo> Schema_DynamicBinding() = 0;
 
 public:

--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -70,6 +70,7 @@ public:
 	virtual void LogFieldInfo( const char* pszFieldName, const char* pszInfo ) = 0;
 	virtual bool FullEdictChanged() = 0;
 	virtual void unk101() = 0;
+	virtual void unk102() = 0;
 	virtual ChangeAccessorFieldPathIndex_t AddChangeAccessorPath( const CFieldPath& path ) = 0;
 	virtual void AssignChangeAccessorPathIds() = 0;
 	virtual ChangeAccessorFieldPathIndexInfo_t* GetChangeAccessorPathInfo_1() = 0;

--- a/public/iserver.h
+++ b/public/iserver.h
@@ -37,7 +37,7 @@ class CCLCMsg_SplitPlayerConnect_t;
 typedef int ChallengeType_t;
 typedef int PauseGroup_t;
 
-abstract_class INetworkGameServer : public IConnectionlessPacketHandler
+abstract_class INetworkGameServer 
 {
 public:
 	virtual	void	Init( const GameSessionConfiguration_t &, const char * ) = 0;


### PR DESCRIPTION
 IConnectionlessPacketHandler is no longer inherited by INetworkGameServer as of the latest version.