### PR TITLE
Enable memoverride in variant.h

### DIFF
--- a/public/variant.h
+++ b/public/variant.h
@@ -17,6 +17,8 @@
 #include "tier1/utlscratchmemory.h"
 #include "resourcefile/resourcetype.h"
 
+#include "tier0/memdbgon.h"
+
 FORWARD_DECLARE_HANDLE( HSCRIPT );
 
 // ========
@@ -974,5 +976,7 @@ typedef CVariantBase<CVariantDefaultAllocator> CVariant;
 typedef CVariantBase<CEntityVariantAllocator> CEntityVariant;
 
 typedef CVariant variant_t;
+
+#include "tier0/memdbgoff.h"
 
 #endif // CVARIANT_H


### PR DESCRIPTION
Specifically, this fixes a "double free or corruption (out)" crash in `CVariantBase::CopyData` [here](https://github.com/alliedmodders/hl2sdk/blob/553058b7608ad81a1e3d542f621a9295b18e3c0d/public/variant.h#L202) when called on a game-allocated `variant_t` object.