### PR TITLE
Fix 2 msvc warnings

### DIFF
--- a/public/bitmap/imageformat.h
+++ b/public/bitmap/imageformat.h
@@ -25,7 +25,7 @@ enum NormalDecodeMode_t
 // Forward declaration
 #ifdef _WIN32
 typedef enum _D3DFORMAT D3DFORMAT;
-typedef enum DXGI_FORMAT;
+enum DXGI_FORMAT;
 #endif
 
 //-----------------------------------------------------------------------------

--- a/public/tier1/keyvalues3.h
+++ b/public/tier1/keyvalues3.h
@@ -337,7 +337,7 @@ public:
 		if (!pszString || !pszString[0])
 			return;
 
-		m_nHashCode = MurmurHash2LowerCase(pszString, strlen(pszString), 0x31415926);
+		m_nHashCode = MurmurHash2LowerCase(pszString, (int)strlen(pszString), 0x31415926);
 		m_pszString = pszString;
 
 #if 0


### PR DESCRIPTION
`hl2sdk-cs2\public\tier1\keyvalues3.h(340,55): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data`

`hl2sdk-cs2\public\bitmap\imageformat.h(28,14): warning C4091: 'typedef ': ignored on left of 'DXGI_FORMAT' when no variable is declared`