### PR TITLE
Add CreateCmdLine overloads from TF2 version 9247927 (2024-10-11)

### DIFF
--- a/public/tier0/icommandline.h
+++ b/public/tier0/icommandline.h
@@ -39,6 +39,10 @@ public:
 	virtual const char* GetParm( int nIndex ) const = 0;
 	
 	virtual bool		HasParm( const char *parm ) = 0;
+	
+	// Additions in 9247927 (2024-10-11)
+	virtual void		CreateCmdLine( const char *commandline, bool unknown ) = 0;
+	virtual void		CreateCmdLine( int argc, char **argv, bool unknown ) = 0;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds the new overloads for `ICommandLine` for the latest TF2 version.

Fixes alliedmodders/sourcemod#2208.