### PR TITLE
Update platform.h

### DIFF
--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -766,8 +766,10 @@ inline T DWordSwapAsm( T dw )
 // The typically used methods.
 //-------------------------------------
 
-#if defined(__i386__) && !defined LITTLE_ENDIAN
+#if !defined LITTLE_ENDIAN
+#if defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
 #define LITTLE_ENDIAN 1
+#endif
 #endif
 
 #if (defined( _SGI_SOURCE ) || defined( _X360 )) && !defined BIG_ENDIAN


### PR DESCRIPTION
This is perhaps an issue spread over all the sdk branches. The detection of little endianess only ever works for gcc, there's nothing for msvc. From my short research, it seems msvc doesn't/never tell the preprocessor anything about the CPU brand. So instead we're going to assume if the CPU is a x86 or x86_64 processor it's most likely intel so i386-family, therefore little endian. Even if there's room for error, this is still marginally better than not having anything defined.