### PR TITLE
Sync IVDebugOverlay with current Black Mesa release

### DIFF
--- a/public/engine/ivdebugoverlay.h
+++ b/public/engine/ivdebugoverlay.h
@@ -39,6 +39,7 @@ public:
 	virtual void AddTextOverlay(const Vector& origin, float duration, PRINTF_FORMAT_STRING const char *format, ...) = 0;
 	virtual void AddTextOverlay(const Vector& origin, int line_offset, float duration, PRINTF_FORMAT_STRING const char *format, ...) = 0;
 	virtual void AddScreenTextOverlay(float flXPos, float flYPos,float flDuration, int r, int g, int b, int a, const char *text) = 0;
+	virtual void AddScreenTextOverlay(float flXPos, float flYPos, int line_offset, float flDuration, int r, int g, int b, int a, const char* text) = 0;
 	virtual void AddSweptBoxOverlay(const Vector& start, const Vector& end, const Vector& mins, const Vector& max, const QAngle & angles, int r, int g, int b, int a, float flDuration) = 0;
 	virtual void AddGridOverlay(const Vector& origin) = 0;
 	virtual int ScreenPosition(const Vector& point, Vector& screen) = 0;


### PR DESCRIPTION
Black Mesa's DebugOverlay also contains an additional function, similar to #128 

My extension was crashing on `engine.dll` when calling [AddScreenTextOverlay](https://github.com/caxanga334/NavBot/blob/main/extension/navmesh/nav_edit.cpp#L952).

Using ghidra, I confirmed the existence of an additional function on the debugoverlay vtable. Based on the function parameters, it appears to be the same function nosoop added to TF2's debugoverlay.

I have tested these changes and my extension no longer crashes.