### PR TITLE
Black Mesa: Add Missing Members to surfacesoundnames_t

### DIFF
--- a/public/vphysics_interface.h
+++ b/public/vphysics_interface.h
@@ -918,6 +918,10 @@ struct surfacesoundnames_t
 
 	unsigned short	breakSound;
 	unsigned short	strainSound;
+	
+	// These two are used to store the "jump" and "land" entries from surfaceproperties.txt
+	unsigned short unknown001;
+	unsigned short unknown002;
 };
 
 struct surfacesoundhandles_t


### PR DESCRIPTION
# Description

My [extension uses the vphysics interface to read surface properties](https://github.com/caxanga334/NavBot/blob/main/extension/navmesh/nav_mesh.cpp#L3537).

I noticed that in Black Mesa, it was reading wrong/garbage values.

I compared the function `CGameMovement::OnLadder` from HL2DM and Black Mesa and noticed that the offset for the variable my extension reads is off by 4. There were 4 extra bytes somewhere on the `surfacephysicsparams_t` struct.

Black Mesa added two entries to surface properties and based on the decompiled output from ghidra of `CPhysicsSurfaceProps::ParseSurfaceDat` from `vphysics_srv.so`, they are stored on `surfacesoundnames_t`.

I am assuming they added these two variables at the bottom of the struct.

# Comparison

Before and after comparison of the values read at `surfacegameprops_t` using Visual Studio's debugger.

## Before Changes

![bms_debugger_before](https://github.com/user-attachments/assets/c805d0da-07bb-48f6-a3b9-f785301eb8c7)

## After Changes

![bms_debugger_after](https://github.com/user-attachments/assets/f74d691d-8102-4667-87dc-d2efb8c778c7)
