### PR TITLE
Fix CNetworkGameServerBase::ConnectClient params

### DIFF
--- a/public/iserver.h
+++ b/public/iserver.h
@@ -32,7 +32,7 @@ class GameSessionConfiguration_t;
 class KeyValues3;
 class CSVCMsg_ServerInfo_t;
 class CServerSideClientBase;
-class CCLCMsg_SplitPlayerConnect_t;
+class C2S_CONNECT_Message;
 
 typedef int ChallengeType_t;
 typedef int PauseGroup_t;
@@ -170,7 +170,7 @@ public:
 
 	virtual void	StartHLTVMaster() = 0;
 
-	virtual CServerSideClientBase *ConnectClient( const char *pszName, ns_address *pAddr, int socket, CCLCMsg_SplitPlayerConnect_t *pSplitPlayer,
+	virtual CServerSideClientBase *ConnectClient( const char *pszName, ns_address *pAddr, void *pNetInfo, C2S_CONNECT_Message *pConnectMsg,
 												  const char *pszChallenge, const byte *pAuthTicket, int nAuthTicketLength, bool bIsLowViolence ) = 0;
 	virtual CServerSideClientBase *CreateNewClient( CPlayerSlot slot ) = 0;
 	


### PR DESCRIPTION
Not personally reversed, but confirmed by:
- Passing `pNetInfo` into `void INetworkSystem::RejectNetChannel(void* pNetInfo, uint32_t reason, void* pUnknown)` (note the S2 interface isn't yet reversed in SDK)
- Accessing `C2S_CONNECT_Message` protobuf message fields