### PR TITLE
Fix ConVarRef GetInt / GetFloat / GetBool

### DIFF
--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -535,7 +535,7 @@ FORCEINLINE_CVAR const char *ConVarRef::GetName() const
 //-----------------------------------------------------------------------------
 FORCEINLINE_CVAR float ConVarRef::GetFloat( void ) const
 {
-	return m_pConVarState->m_fValue;
+	return m_pConVarState->GetFloat();
 }
 
 //-----------------------------------------------------------------------------
@@ -543,7 +543,7 @@ FORCEINLINE_CVAR float ConVarRef::GetFloat( void ) const
 //-----------------------------------------------------------------------------
 FORCEINLINE_CVAR int ConVarRef::GetInt( void ) const 
 {
-	return m_pConVarState->m_nValue;
+	return m_pConVarState->GetInt();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Black Mesa made some changes to how `ConVar` values are stored.

This fixes `ConVarRef` GetInt / GetFloat / GetBool returning incorrect values by calling the virtual GetInt / GetFloat functions instead of reading the stored values directly.

