### PR TITLE
CSS: remove 'register' keyword for C++17 compat

### DIFF
--- a/public/mathlib/mathlib.h
+++ b/public/mathlib/mathlib.h
@@ -328,7 +328,7 @@ void inline SinCos( float radians, float *sine, float *cosine )
 		fstp DWORD PTR [eax]
 	}
 #elif defined( _LINUX ) || defined ( __APPLE__ )
-	register double __cosr, __sinr;
+	double __cosr, __sinr;
  	__asm __volatile__
     		("fsincos"
      	: "=t" (__cosr), "=u" (__sinr) : "0" (radians));


### PR DESCRIPTION
On Linux you'll probably get errors like this if you're targeting C++17 or higher:
```
 ../_external/alliedmodders/sourcemod/public/CDetour/detours.cpp:1:
  In file included from ../_external/alliedmodders/sourcemod/public/CDetour/detours.h:36:
  In file included from ../_external/alliedmodders/sourcemod/public/smsdk_ext.h:100:
  In file included from ../_external/alliedmodders/mmsource/core/ISmmPlugin.h:39:
  In file included from ../_external/alliedmodders/mmsource/core/ISmmAPI.h:45:
  In file included from ../_external/alliedmodders/hl2sdk-css/public/eiface.h:16:
  In file included from ../_external/alliedmodders/hl2sdk-css/public/tier1/convar.h:21:
  In file included from ../_external/alliedmodders/hl2sdk-css/public/tier1/utlvector.h:23:
  In file included from ../_external/alliedmodders/hl2sdk-css/public/tier1/utlmemory.h:20:
  ../_external/alliedmodders/hl2sdk-css/public/mathlib/mathlib.h:331:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    331 |         register double __cosr, __sinr;
        |         ^~~~~~~~
  ../_external/alliedmodders/hl2sdk-css/public/mathlib/mathlib.h:331:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
    331 |         register double __cosr, __sinr;
        |         ^~~~~~~~
```