### PR TITLE
[Day of Defeat: Source] Remove Deprecated 'register' Keyword

### DIFF
--- a/public/mathlib/mathlib.h
+++ b/public/mathlib/mathlib.h
@@ -328,7 +328,7 @@ void inline SinCos( float radians, float *sine, float *cosine )
 		fstp DWORD PTR [eax]
 	}
 #elif defined( _LINUX ) || defined ( __APPLE__ )
-	register double __cosr, __sinr;
+	double __cosr, __sinr;
  	__asm __volatile__
     		("fsincos"
      	: "=t" (__cosr), "=u" (__sinr) : "0" (radians));


### PR DESCRIPTION
Fixes this compile error when using C++17 or better.

```
/home/caxanga334/Documents/alliedmodders/hl2sdk-dods/public/mathlib/mathlib.h:331:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
  331 |         register double __cosr, __sinr;
```

Closes #288 