### PR TITLE
Add CHostStateRequest, update tier2.h

### DIFF
--- a/public/engine/hoststate.h
+++ b/public/engine/hoststate.h
@@ -1,19 +1,11 @@
 #include "tier1/utlstring.h"
 #include "tier1/KeyValues.h"
 #include "appframework/IAppSystem.h"
-#include "tier2.h"
+#include "tier2/tier2.h"
 
 struct ResourceManifestDesc_t;
 
-typedef enum
-{
-	HOST_STATE_LOOP_MODE_IDLE = 1,
-	HOST_STATE_LOOP_MODE_GAME,
-	HOST_STATE_LOOP_MODE_SOURCETV_RELAY,
-	HOST_STATE_LOOP_MODE_QUIT
-} HostStateLoopModeType_t;
-
-typedef enum
+enum HostMode_t
 {
 	HM_LEVEL_LOAD_SERVER = 1,
 	HM_CONNECT,
@@ -23,7 +15,7 @@ typedef enum
 	HM_PLAY_DEMO,
 	HM_SOURCETV_RELAY,
 	HM_ADDON_DOWNLOAD
-} HostMode_t;
+};
 
 struct CHostStateRequest
 {
@@ -42,8 +34,6 @@ struct CHostStateRequest
 	CUtlString m_Addons;
 	KeyValues *m_KV;
 };
-
-static_assert(sizeof(CHostStateRequest) == 0x68, "CHostStateRequest size mismatch");
 
 class ISwitchLoopModeStatusNotify
 {

--- a/public/engine/hoststate.h
+++ b/public/engine/hoststate.h
@@ -67,18 +67,18 @@ class IHostStateMgr : public IAppSystem
 class CHostStateMgr : public CTier2AppSystem<IHostStateMgr>, public ISwitchLoopModeStatusNotify
 {
 public:
-	CHostStateRequest *pendingRequest;              // 0x30
-	CHostStateRequest *currentRequest;              // 0x38
-	CUtlString m_LoopModeType;                      // 0x40 console/game
-	KeyValues *m_GameConfigurationKV;               // 0x48
-	CUtlString m_LoopMode;                          // 0x50
-	KeyValues *m_RemoteConnectKV;                   // 0x58
-	uint8_t unknown[8];                             // 0x60
-	CUtlString m_Address;                           // 0x68
-	CUtlString m_SaveGame;                          // 0x70
-	CUtlString m_LevelName;                         // 0x78
-	CUtlString m_Addons;                            // 0x80
-	KeyValues *m_KV;                                // 0x88
-	int m_ID;                                       // 0x90
-	CUtlVector<CHostStateRequest> m_QueuedRequests; // 0x98
+	CHostStateRequest *m_PendingRequest;              // 0x30
+	CHostStateRequest *m_CurrentRequest;              // 0x38
+	CUtlString m_LoopModeType;                        // 0x40 console/game
+	KeyValues *m_pGameConfigurationKV;                // 0x48
+	CUtlString m_LoopMode;                            // 0x50
+	KeyValues *m_pConnectKV;                          // 0x58
+	CUtlString m_LoopModeName;                        // 0x60
+	CUtlString m_Address;                             // 0x68
+	CUtlString m_SaveGame;                            // 0x70
+	CUtlString m_LevelName;                           // 0x78
+	CUtlString m_Addons;                              // 0x80
+	KeyValues *m_pKV;                                 // 0x88
+	int m_ID;                                         // 0x90
+	CUtlVector<CHostStateRequest *> m_QueuedRequests; // 0x98
 };

--- a/public/engine/hoststate.h
+++ b/public/engine/hoststate.h
@@ -5,7 +5,15 @@
 
 struct ResourceManifestDesc_t;
 
-enum HostMode_t
+enum HostStateRequestType_t
+{
+	HSR_IDLE = 1,
+	HSR_GAME,
+	HSR_SOURCETV_RELAY,
+	HSR_QUIT
+};
+
+enum HostStateRequestMode_t
 {
 	HM_LEVEL_LOAD_SERVER = 1,
 	HM_CONNECT,
@@ -19,20 +27,20 @@ enum HostMode_t
 
 struct CHostStateRequest
 {
-	HostStateLoopModeType_t m_iType;
+	HostStateRequestType_t m_iType;
 	CUtlString m_LoopModeType;
 	CUtlString m_Desc;
 	bool m_bActive;
 	unsigned int m_ID;
-	HostMode_t m_iMode;
+	HostStateRequestMode_t m_iMode;
 	CUtlString m_LevelName;
 	bool m_bChangelevel;
 	CUtlString m_SaveGame;
 	CUtlString m_Address;
 	CUtlString m_DemoFile;
-	bool m_bLoadmap;
+	bool m_bLoadMap;
 	CUtlString m_Addons;
-	KeyValues *m_KV;
+	KeyValues *m_pKV;
 };
 
 class ISwitchLoopModeStatusNotify

--- a/public/engine/hoststate.h
+++ b/public/engine/hoststate.h
@@ -1,0 +1,86 @@
+#include "tier1/utlstring.h"
+#include "tier1/KeyValues.h"
+#include "appframework/IAppSystem.h"
+#include "tier2.h"
+
+struct ResourceManifestDesc_t;
+
+typedef enum
+{
+	HOST_STATE_LOOP_MODE_IDLE = 1,
+	HOST_STATE_LOOP_MODE_GAME,
+	HOST_STATE_LOOP_MODE_SOURCETV_RELAY,
+	HOST_STATE_LOOP_MODE_QUIT
+} HostStateLoopModeType_t;
+
+typedef enum
+{
+	HM_LEVEL_LOAD_SERVER = 1,
+	HM_CONNECT,
+	HM_CHANGE_LEVEL,
+	HM_LEVEL_LOAD_LISTEN,
+	HM_LOAD_SAVE,
+	HM_PLAY_DEMO,
+	HM_SOURCETV_RELAY,
+	HM_ADDON_DOWNLOAD
+} HostMode_t;
+
+struct CHostStateRequest
+{
+	HostStateLoopModeType_t m_iType;
+	CUtlString m_LoopModeType;
+	CUtlString m_Desc;
+	bool m_bActive;
+	unsigned int m_ID;
+	HostMode_t m_iMode;
+	CUtlString m_LevelName;
+	bool m_bChangelevel;
+	CUtlString m_SaveGame;
+	CUtlString m_Address;
+	CUtlString m_DemoFile;
+	bool m_bLoadmap;
+	CUtlString m_Addons;
+	KeyValues *m_KV;
+};
+
+static_assert(sizeof(CHostStateRequest) == 0x68, "CHostStateRequest size mismatch");
+
+class ISwitchLoopModeStatusNotify
+{
+	virtual void OnSwitchLoopModeFinished(const char *, uint32, bool) = 0;
+};
+
+class IHostStateMgr : public IAppSystem
+{
+	virtual void RequestHS_Quit(void) = 0;
+	virtual void RequestHS_Idle(KeyValues *) = 0;
+	virtual void RequestHS_Connect(const char *, KeyValues *) = 0;
+	virtual void RequestHS_ChangelevelReconnect(const char *, KeyValues *) = 0;
+	virtual void RequestHS_LoadSpawnGroup(const char *, const char *, bool, KeyValues *) = 0;
+	virtual void RequestHS_LoadSaveGame(const char *, const char *, KeyValues *) = 0;
+	virtual void RequestHS_PlayDemo(const char *, const char *, bool, KeyValues *) = 0;
+	virtual void RequestHS_PlayBroadcast(const char *, KeyValues *) = 0;
+	virtual void RequestHS_DownloadAddons(KeyValues *) = 0;
+	virtual void RequestHS_SourceTVRelay(const char *, KeyValues *) = 0;
+	virtual void RequestHS_ReloadLastSaveGame(void) = 0;
+	virtual void RequestHS_RestartSpawnGroups(void) = 0;
+};
+
+class CHostStateMgr : public CTier2AppSystem<IHostStateMgr>, public ISwitchLoopModeStatusNotify
+{
+public:
+	CHostStateRequest *pendingRequest;              // 0x30
+	CHostStateRequest *currentRequest;              // 0x38
+	CUtlString m_LoopModeType;                      // 0x40 console/game
+	KeyValues *m_GameConfigurationKV;               // 0x48
+	CUtlString m_LoopMode;                          // 0x50
+	KeyValues *m_RemoteConnectKV;                   // 0x58
+	uint8_t unknown[8];                             // 0x60
+	CUtlString m_Address;                           // 0x68
+	CUtlString m_SaveGame;                          // 0x70
+	CUtlString m_LevelName;                         // 0x78
+	CUtlString m_Addons;                            // 0x80
+	KeyValues *m_KV;                                // 0x88
+	int m_ID;                                       // 0x90
+	CUtlVector<CHostStateRequest> m_QueuedRequests; // 0x98
+};

--- a/public/tier2/tier2.h
+++ b/public/tier2/tier2.h
@@ -13,7 +13,7 @@
 #endif
 
 #include "tier1/tier1.h"
-
+struct ResourceManifestDesc_t;
 
 //-----------------------------------------------------------------------------
 // Call this to connect to/disconnect from all tier 2 libraries.
@@ -80,6 +80,9 @@ public:
 		DisconnectTier2Libraries();
 		BaseClass::Disconnect();
 	}
+private:
+	CUtlVector<ResourceManifestDesc_t *> m_manualManifests;
+	int m_nAppSysTier2LibraryConnects;
 };
 
 


### PR DESCRIPTION
CTier2AppSystem introduces a vector and an int, the changes are made so CHostStateMgr's vtables are positioned correctly. HostMode_t is educated guess while HostStateLoopModeType_t was taken from dota 2 binary.