### PR TITLE
CS2: Remove register from generichash

### DIFF
--- a/tier1/generichash.cpp
+++ b/tier1/generichash.cpp
@@ -125,7 +125,7 @@ unsigned FASTCALL HashStringConventional( const char *pszKey )
 //-----------------------------------------------------------------------------
 unsigned FASTCALL HashInt( const int n )
 {
-	register unsigned		even, odd;
+	unsigned		even, odd;
 	even  = g_nRandomValues[n & 0xff];
 	odd   = g_nRandomValues[((n >> 8) & 0xff)];
 
@@ -142,8 +142,8 @@ unsigned FASTCALL HashInt( const int n )
 //-----------------------------------------------------------------------------
 unsigned FASTCALL Hash4( const void *pKey )
 {
-	register const uint32 *	p = (const uint32 *) pKey;
-	register unsigned		even,
+	const uint32 *	p = (const uint32 *) pKey;
+	unsigned		even,
 							odd,
 							n;
 	n     = *p;
@@ -164,8 +164,8 @@ unsigned FASTCALL Hash4( const void *pKey )
 //-----------------------------------------------------------------------------
 unsigned FASTCALL Hash8( const void *pKey )
 {
-	register const uint32 *	p = (const uint32 *) pKey;
-	register unsigned		even,
+	const uint32 *	p = (const uint32 *) pKey;
+	unsigned		even,
 							odd,
 							n;
 	n     = *p;
@@ -192,8 +192,8 @@ unsigned FASTCALL Hash8( const void *pKey )
 //-----------------------------------------------------------------------------
 unsigned FASTCALL Hash12( const void *pKey )
 {
-	register const uint32 *	p = (const uint32 *) pKey;
-	register unsigned		even,
+	const uint32 *	p = (const uint32 *) pKey;
+	unsigned		even,
 							odd,
 							n;
 	n     = *p;
@@ -226,8 +226,8 @@ unsigned FASTCALL Hash12( const void *pKey )
 //-----------------------------------------------------------------------------
 unsigned FASTCALL Hash16( const void *pKey )
 {
-	register const uint32 *	p = (const uint32 *) pKey;
-	register unsigned		even,
+	const uint32 *	p = (const uint32 *) pKey;
+	unsigned		even,
 							odd,
 							n;
 	n     = *p;


### PR DESCRIPTION
Fixes `ISO C++17 does not allow ‘register’ storage class specifier`

It was already fixed in tf2 branch after the sdk sync.