### PR TITLE
Update ISource2GameClients missing function and ICvar type

### DIFF
--- a/public/eiface.h
+++ b/public/eiface.h
@@ -601,7 +601,7 @@ public:
 	virtual void			ClientCommand( CPlayerSlot slot, const CCommand &args ) = 0;
 
 	// Set the the client controller's userinfo cvar value set to the specified address.
-	virtual void			ClientSetConVarUserInfoSet( CPlayerSlot slot, ConVarUserInfoSet_t *pConVarUserInfoSet ) = 0;
+	virtual void			ClientSetConVarUserInfoSet( CPlayerSlot slot, ConVarUserInfoSet_t pConVarUserInfoSet ) = 0;
 	// A player changed one/several replicated cvars (name etc)
 	virtual void			ClientSettingsChanged( CPlayerSlot slot ) = 0;
 

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -600,6 +600,8 @@ public:
 	// The client has typed a command at the console
 	virtual void			ClientCommand( CPlayerSlot slot, const CCommand &args ) = 0;
 
+	// Set the the client controller's userinfo cvar value set to the specified address.
+	virtual void			ClientSetConVarUserInfoSet( CPlayerSlot slot, ConVarUserInfoSet_t *pConVarUserInfoSet ) = 0;
 	// A player changed one/several replicated cvars (name etc)
 	virtual void			ClientSettingsChanged( CPlayerSlot slot ) = 0;
 

--- a/public/icvar.h
+++ b/public/icvar.h
@@ -39,7 +39,7 @@
 // Shorthand helper to iterate registered concommands
 #define FOR_EACH_CONCOMMAND( iter ) for(ConCommandRef iter = icvar->FindFirstConCommand(); iter.IsValidRef(); iter = icvar->FindNextConCommand( iter ))
 
-
+struct ConVarUserInfoSet_t;
 struct ConVarSnapshot_t;
 class KeyValues;
 

--- a/public/icvar.h
+++ b/public/icvar.h
@@ -39,7 +39,7 @@
 // Shorthand helper to iterate registered concommands
 #define FOR_EACH_CONCOMMAND( iter ) for(ConCommandRef iter = icvar->FindFirstConCommand(); iter.IsValidRef(); iter = icvar->FindNextConCommand( iter ))
 
-struct ConVarUserInfoSet_t;
+typedef uint8 *ConVarUserInfoSet_t;
 struct ConVarSnapshot_t;
 class KeyValues;
 
@@ -117,7 +117,7 @@ public:
 	virtual int					GetTotalUserInfoCvarsByteSize() = 0;
 	// Copies default values of all cvars which have FCVAR_USERINFO flag to the buffer in a byte range from->to
 	// if copy_or_cleanup is true, if false would cleanup the buffer
-	virtual void				CopyUserInfoCvarDefaults( uint8* buffer, int from, int to, bool copy_or_cleanup ) = 0;
+	virtual void				CopyUserInfoCvarDefaults( ConVarUserInfoSet_t buffer, int from, int to, bool copy_or_cleanup ) = 0;
 
 	// Register, unregister vars
 	virtual void				RegisterConVar( const ConVarCreation_t& setup, uint64 nAdditionalFlags, ConVarRef* pCvarRef, ConVarData** pCvarData ) = 0;


### PR DESCRIPTION
The player controller datamap now has `m_hConVarUserInfoSet` property which is shared with the client's userinfo set upon connection and is set to 0 when the player disconnects.
