### PR TITLE
Add RejectNetChannel to INetworkSystem

### DIFF
--- a/public/networksystem/inetworksystem.h
+++ b/public/networksystem/inetworksystem.h
@@ -130,14 +130,16 @@ public:
 
 	virtual void unk301() = 0;
 	virtual void unk302() = 0;
-	virtual void RejectNetChannel(void *pNetInfo, ENetworkDisconnectionReason reason, void * = nullptr) = 0;
-	virtual void unk304() = 0;
-	virtual void unk305() = 0;
 
-	virtual void InitNetworkSystem() = 0;
+	virtual void RejectConnection( uint32 steam_handle, ENetworkDisconnectionReason reason, void * = nullptr ) = 0;
 
 	virtual void unk401() = 0;
 	virtual void unk402() = 0;
+
+	virtual void InitNetworkSystem() = 0;
+
+	virtual void unk501() = 0;
+	virtual void unk502() = 0;
 
 	virtual ~INetworkSystem() = 0;
 };

--- a/public/networksystem/inetworksystem.h
+++ b/public/networksystem/inetworksystem.h
@@ -130,7 +130,7 @@ public:
 
 	virtual void unk301() = 0;
 	virtual void unk302() = 0;
-	virtual void unk303() = 0;
+	virtual void RejectNetChannel(void *pNetInfo, ENetworkDisconnectionReason reason, void * = nullptr) = 0;
 	virtual void unk304() = 0;
 	virtual void unk305() = 0;
 


### PR DESCRIPTION
`pNetInfo` is the same type used in [ConnectClient](https://github.com/alliedmodders/hl2sdk/blob/38881d68a49a8219d41a472a508fbf6a7f94ac1a/public/iserver.h#L191), as mentioned last time, treating it as `INetChannel`/`INetChannelInfo` did not seem to work, so I don't know the actual type.