### PR TITLE
Fix CNetworkGameServerBase::ConnectClient param type

### DIFF
--- a/public/iserver.h
+++ b/public/iserver.h
@@ -188,7 +188,7 @@ public:
 
 	virtual void	StartHLTVMaster() = 0;
 
-	virtual CServerSideClientBase *ConnectClient( const char *pszName, ns_address *pAddr, void *pNetInfo, C2S_CONNECT_Message *pConnectMsg,
+	virtual CServerSideClientBase *ConnectClient( const char *pszName, ns_address *pAddr, uint32 steam_handle, C2S_CONNECT_Message *pConnectMsg,
 												  const char *pszChallenge, const byte *pAuthTicket, int nAuthTicketLength, bool bIsLowViolence ) = 0;
 	virtual CServerSideClientBase *CreateNewClient( CPlayerSlot slot ) = 0;
 	


### PR DESCRIPTION
I previously regressed this in #290, however the correct type is now used in https://github.com/alliedmodders/hl2sdk/commit/8450d3aeac30a979d6f372a3b9a516f5c9b653e2.