### PR TITLE
Fix networkvar.h Compile Error on x86-64

### DIFF
--- a/public/networkvar.h
+++ b/public/networkvar.h
@@ -22,7 +22,7 @@
 #pragma warning( disable : 4284 ) // warning C4284: return type for 'CNetworkVarT<int>::operator ->' is 'int *' (ie; not a UDT or reference to a UDT.  Will produce errors if applied using infix notation)
 #endif
 
-#define MyOffsetOf( type, var ) ( (int)&((type*)0)->var )
+#define MyOffsetOf( type, var ) ( (int)(intp)&((type*)0)->var )
 
 #ifdef _DEBUG
 	#undef new


### PR DESCRIPTION
# Description

Fixes the following error when compiling for x86-64 against the CS:GO HL2-SDK.

```
/home/caxanga334/Documents/alliedmodders/hl2sdk-csgo/public/PlayerState.h:32:2: error: cast from pointer to smaller type 'int' loses information
   32 |         CNetworkVar( bool, deadflag );
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/caxanga334/Documents/alliedmodders/hl2sdk-csgo/public/networkvar.h:655:2: note: expanded from macro 'CNetworkVar'
  655 |         NETWORK_VAR_END( type, name, CNetworkVarBase, NetworkStateChanged )
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/caxanga334/Documents/alliedmodders/hl2sdk-csgo/public/networkvar.h:815:54: note: expanded from macro 'NETWORK_VAR_END'
  815 |                         CHECK_USENETWORKVARS ((ThisClass*)(((char*)ptr) - MyOffsetOf(ThisClass,name)))->stateChangedFn( ptr ); \
      |                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/caxanga334/Documents/alliedmodders/hl2sdk-csgo/public/networkvar.h:25:35: note: expanded from macro 'MyOffsetOf'
   25 | #define MyOffsetOf( type, var ) ( (int)&((type*)0)->var )
      |                                   ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

The fix is ported from the public [Source SDK 2013 networkvar.h](https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/public/networkvar.h#L24) file.
