### PR TITLE
[L4D2] Added missing fields to the `CTakeDamageInfo` class

### DIFF
--- a/game/shared/takedamageinfo.cpp
+++ b/game/shared/takedamageinfo.cpp
@@ -16,18 +16,20 @@ ConVar phys_pushscale( "phys_pushscale", "1", FCVAR_REPLICATED );
 
 BEGIN_SIMPLE_DATADESC( CTakeDamageInfo )
 	DEFINE_FIELD( m_vecDamageForce, FIELD_VECTOR ),
-	DEFINE_FIELD( m_vecDamagePosition, FIELD_POSITION_VECTOR),
-	DEFINE_FIELD( m_vecReportedPosition, FIELD_POSITION_VECTOR),
-	DEFINE_FIELD( m_hInflictor, FIELD_EHANDLE),
-	DEFINE_FIELD( m_hAttacker, FIELD_EHANDLE),
-	DEFINE_FIELD( m_hWeapon, FIELD_EHANDLE),
-	DEFINE_FIELD( m_flDamage, FIELD_FLOAT),
-	DEFINE_FIELD( m_flMaxDamage, FIELD_FLOAT),
+	DEFINE_FIELD( m_vecDamagePosition, FIELD_POSITION_VECTOR ),
+	DEFINE_FIELD( m_vecReportedPosition, FIELD_POSITION_VECTOR ),
+	DEFINE_FIELD( m_hInflictor, FIELD_EHANDLE ),
+	DEFINE_FIELD( m_hAttacker, FIELD_EHANDLE ),
+	DEFINE_FIELD( m_hWeapon, FIELD_EHANDLE ),
+	DEFINE_FIELD( m_flDamage, FIELD_FLOAT ),
+	DEFINE_FIELD( m_flMaxDamage, FIELD_FLOAT ),
 	DEFINE_FIELD( m_flBaseDamage, FIELD_FLOAT ),
-	DEFINE_FIELD( m_bitsDamageType, FIELD_INTEGER),
-	DEFINE_FIELD( m_iDamageCustom, FIELD_INTEGER),
-	DEFINE_FIELD( m_iDamageStats, FIELD_INTEGER),
-	DEFINE_FIELD( m_iAmmoType, FIELD_INTEGER),
+	DEFINE_FIELD( m_bitsDamageType, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iDamageCustom, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iDamageStats, FIELD_INTEGER ),
+	DEFINE_FIELD( m_iAmmoType, FIELD_INTEGER ),
+	DEFINE_FIELD( m_flRadius, FIELD_FLOAT ),
+	DEFINE_FIELD( m_iDamageVictimIndex, FIELD_INTEGER ),
 END_DATADESC()
 
 void CTakeDamageInfo::Init( CBaseEntity *pInflictor, CBaseEntity *pAttacker, CBaseEntity *pWeapon, const Vector &damageForce, const Vector &damagePosition, const Vector &reportedPosition, float flDamage, int bitsDamageType, int iCustomDamage )
@@ -56,6 +58,10 @@ void CTakeDamageInfo::Init( CBaseEntity *pInflictor, CBaseEntity *pAttacker, CBa
 	m_vecDamagePosition = damagePosition;
 	m_vecReportedPosition = reportedPosition;
 	m_iAmmoType = -1;
+
+	m_vecDamageDirection = vec3_origin;
+	m_flRadius = 0.0;
+	m_iDamageVictimIndex = 0;
 }
 
 CTakeDamageInfo::CTakeDamageInfo()

--- a/game/shared/takedamageinfo.h
+++ b/game/shared/takedamageinfo.h
@@ -80,6 +80,15 @@ public:
 	void			SetAmmoType( int iAmmoType );
 	const char *	GetAmmoName() const;
 
+	Vector			GetDamageDirection() const;
+	void			SetDamageDirection( const Vector &damageDirection );
+
+	float			GetRadius() const;
+	void			SetRadius( float flRadius );
+
+	float			GetVictimIndex() const;
+	void			SetVictimIndex( int iVictimIndex );
+
 	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, float flDamage, int bitsDamageType, int iKillType = 0 );
 	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, CBaseEntity *pWeapon, float flDamage, int bitsDamageType, int iKillType = 0 );
 	void			Set( CBaseEntity *pInflictor, CBaseEntity *pAttacker, const Vector &damageForce, const Vector &damagePosition, float flDamage, int bitsDamageType, int iKillType = 0, Vector *reportedPosition = NULL );
@@ -102,7 +111,7 @@ protected:
 	Vector			m_vecDamageForce;
 	Vector			m_vecDamagePosition;
 	Vector			m_vecReportedPosition;	// Position players are told damage is coming from
-	Vector			m_vecUnknown;
+	Vector			m_vecDamageDirection;	// The type matches, but I'm not sure about the name; the name is taken from new games.
 	EHANDLE			m_hInflictor;
 	EHANDLE			m_hAttacker;
 	EHANDLE			m_hWeapon;
@@ -113,6 +122,8 @@ protected:
 	int				m_iDamageCustom;
 	int				m_iDamageStats;
 	int				m_iAmmoType;			// AmmoType of the weapon used to cause this damage, if any
+	int				m_flRadius;
+	int				m_iDamageVictimIndex;
 
 	DECLARE_SIMPLE_DATADESC();
 };
@@ -331,6 +342,35 @@ inline void CTakeDamageInfo::CopyDamageToBaseDamage()
 	m_flBaseDamage = m_flDamage;
 }
 
+inline Vector CTakeDamageInfo::GetDamageDirection() const
+{
+	return m_vecDamageDirection;
+}
+
+inline void CTakeDamageInfo::SetDamageDirection( const Vector &damageDirection )
+{
+	m_vecDamageDirection = damageDirection;
+}
+
+inline float CTakeDamageInfo::GetRadius() const
+{
+	return m_flRadius;
+}
+
+inline void CTakeDamageInfo::SetRadius( float flRadius )
+{
+	m_flRadius = flRadius;
+}
+
+inline float CTakeDamageInfo::GetVictimIndex() const
+{
+	return m_iDamageVictimIndex;
+}
+
+inline void CTakeDamageInfo::SetVictimIndex( int iVictimIndex )
+{
+	m_iDamageVictimIndex = iVictimIndex;
+}
 
 // -------------------------------------------------------------------------------------------------- //
 // Inlines.


### PR DESCRIPTION
**Description:**
- The actual size of `CTakeDamageInfo` is 96 bytes.

- Updated `CTakeDamageInfo` to include new class fields (`m_flRadius` and `m_iDamageVictimIndex`) for clarity and future compatibility.

- Existing hooks remain fully compatible.

- Crashes in SourceMod do not occur due to an incorrect stack, because the structure is always passed by reference or pointer.

- Updating the structure is recommended for cases where manual access to all fields or other special use cases is required.

**DataMap `CTakeDamageInfo`:**
```
.data:00F096A0                               ; datamap_t * DataMapInit<CTakeDamageInfo>(CTakeDamageInfo *)::dataDesc
.data:00F096A0 00                            _ZZ11DataMapInitI15CTakeDamageInfoEP9datamap_tPT_E8dataDesc db    0
.data:00F096E4 82 EE C0 00                                   dd offset aMVecdamageforc ; "m_vecDamageForce"
.data:00F096E8 00                                            db    0
.data:00F09724 93 EE C0 00                                   dd offset aMVecdamageposi ; "m_vecDamagePosition"
.data:00F09728 0C                                            db  0Ch
.data:00F09764 A7 EE C0 00                                   dd offset aMVecreportedpo ; "m_vecReportedPosition"
.data:00F09768 18                                            db  18h
.data:00F097A4 BD EE C0 00                                   dd offset aMHinflictor  ; "m_hInflictor"
.data:00F097A8 30                                            db  30h ; 0
.data:00F097E4 CA EE C0 00                                   dd offset aMHattacker   ; "m_hAttacker"
.data:00F097E8 34                                            db  34h ; 4
.data:00F09824 46 9E BF 00                                   dd offset aMHweapon     ; "m_hWeapon"
.data:00F09828 38                                            db  38h ; 8
.data:00F09864 56 8E BF 00                                   dd offset aMFldamage    ; "m_flDamage"
.data:00F09868 3C                                            db  3Ch ; <
.data:00F098A4 D6 EE C0 00                                   dd offset aMFlmaxdamage ; "m_flMaxDamage"
.data:00F098A8 40                                            db  40h ; @
.data:00F098E4 E4 EE C0 00                                   dd offset aMFlbasedamage ; "m_flBaseDamage"
.data:00F098E8 44                                            db  44h ; D
.data:00F09924 F3 EE C0 00                                   dd offset aMBitsdamagetyp ; "m_bitsDamageType"
.data:00F09928 48                                            db  48h ; H
.data:00F09964 04 EF C0 00                                   dd offset aMIdamagecustom ; "m_iDamageCustom"
.data:00F09968 4C                                            db  4Ch ; L
.data:00F099A4 14 EF C0 00                                   dd offset aMIdamagestats ; "m_iDamageStats"
.data:00F099A8 50                                            db  50h ; P
.data:00F099E4 23 EF C0 00                                   dd offset aMIammotype   ; "m_iAmmoType"
.data:00F099E8 54                                            db  54h ; T
.data:00F09A24 02 BB BF 00                                   dd offset aMFlradius    ; "m_flRadius"
.data:00F09A28 58                                            db  58h ; X
.data:00F09A64 2F EF C0 00                                   dd offset aMIdamagevictim ; "m_iDamageVictimIndex"
.data:00F09A68 5C                                            db  5Ch ; \
```

**Screen from game library:**
<img width="2557" height="1373" alt="Screen 2025-10-19 191403" src="https://github.com/user-attachments/assets/cd7a7661-4e93-47b2-8448-0a7c73fb99ee" />

**Verification:**
- The sourcemod was successfully built using the updated `hl2sdk-l4d2`.
