### PR TITLE
[L4D2] Update `IKeyValuesSystem` class

### DIFF
--- a/public/vstdlib/IKeyValuesSystem.h
+++ b/public/vstdlib/IKeyValuesSystem.h
@@ -41,6 +41,11 @@ public:
 	// for debugging, adds KeyValues record into global list so we can track memory leaks
 	virtual void AddKeyValuesToMemoryLeakList(void *pMem, HKeySymbol name) = 0;
 	virtual void RemoveKeyValuesFromMemoryLeakList(void *pMem) = 0;
+	
+	// set/get a value for keyvalues resolution symbol
+	// e.g.: SetKeyValuesExpressionSymbol( "LOWVIOLENCE", true ) - enables [$LOWVIOLENCE]
+	virtual void SetKeyValuesExpressionSymbol( const char *name, bool bValue ) = 0;
+	virtual bool GetKeyValuesExpressionSymbol( const char *name ) = 0;
 };
 
 VSTDLIB_INTERFACE IKeyValuesSystem *KeyValuesSystem();


### PR DESCRIPTION
Add missing virtual functions to class `IKeyValuesSystem`.