### PR TITLE
tf2: Clarify use of overload CUtlSymbolTable::Find

### DIFF
--- a/public/tier1/utlsymbol.h
+++ b/public/tier1/utlsymbol.h
@@ -105,7 +105,7 @@ public:
 	
 	inline bool HasElement( const char* pStr ) const
 	{
-		return Find( pStr ) != UTL_INVAL_SYMBOL;
+		return (UtlSymId_t)(Find( pStr )) != UTL_INVAL_SYMBOL;
 	}
 
 	// Remove all symbols in the table.


### PR DESCRIPTION
This fixes an error that occurs when trying to compile for C++20 on Windows or Linux:
```
public/tier1/utlsymbol.h:108:23: error: use of overloaded operator '!=' is ambiguous (with operand types 'CUtlSymbol' and 'UtlSymId_t' (aka 'unsigned short'))
                return Find( pStr ) != UTL_INVAL_SYMBOL;
                       ~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~
```

