### PR TITLE
Update ILoopModePrerequisiteRegistry and IEngineServiceMgr

### DIFF
--- a/public/engine/IEngineService.h
+++ b/public/engine/IEngineService.h
@@ -77,7 +77,7 @@ public:
 	virtual void		ChangeVideoMode( RenderDeviceInfo_t & ) = 0;
 	virtual void		GetVideoModeChange( void ) = 0;
 	virtual int			GetAddonCount( void ) const = 0;
-	virtual const char*	GetAddon( int ) const = 0;
+	virtual const char	*GetAddon( int ) const = 0;
 	virtual bool		IsAddonMounted( const char * ) const = 0;
 	virtual const char	*GetAddonsString( void ) const = 0;
 	virtual void		unk101( void ) = 0;

--- a/public/engine/IEngineService.h
+++ b/public/engine/IEngineService.h
@@ -13,6 +13,7 @@
 #include <appframework/IAppSystem.h>
 #include <inputsystem/InputEnums.h>
 #include <iloopmode.h>
+#include <localize/ilocalize.h>
 
 class ISwitchLoopModeStatusNotify;
 class IAddonListChangeNotify;
@@ -68,8 +69,6 @@ public:
 	virtual CEventDispatcher<CEventIDManager_Default>* GetEventDispatcher(void) = 0;
 	virtual void		*GetDebugVisualizerMgr( void ) = 0;
 	virtual int			GetActiveLoopClientServerMode( void ) const = 0;
-	virtual void		EnableMaxFramerate( bool ) = 0;
-	virtual void		OverrideMaxFramerate( float ) = 0;
 	virtual void		PrintStatus( void ) = 0;
 	virtual ActiveLoop_t	GetActiveLoop( void ) = 0;
 	virtual bool		IsLoadingLevel( void ) const = 0;
@@ -78,14 +77,34 @@ public:
 	virtual void		ChangeVideoMode( RenderDeviceInfo_t & ) = 0;
 	virtual void		GetVideoModeChange( void ) = 0;
 	virtual int			GetAddonCount( void ) const = 0;
-	virtual void		GetAddon( int ) const = 0;
+	virtual const char*	GetAddon( int ) const = 0;
 	virtual bool		IsAddonMounted( const char * ) const = 0;
 	virtual const char	*GetAddonsString( void ) const = 0;
+	virtual void		unk101( void ) = 0;
+	virtual void		unk102( void ) = 0;
+	virtual void		unk103( void ) = 0;
 	virtual void		InstallSwitchLoopModeStatusNotify( ISwitchLoopModeStatusNotify * ) = 0;
 	virtual void		UninstallSwitchLoopModeStatusNotify( ISwitchLoopModeStatusNotify * ) = 0;
 	virtual void		InstallAddonListChangeNotify( IAddonListChangeNotify * ) = 0;
 	virtual void		UninstallAddonListChangeNotify( IAddonListChangeNotify * ) = 0;
+	virtual void		StartEngineWatchdogThread( void ) = 0;
+	virtual void		AddLogCaptureString( const char * ) = 0;
+	virtual void		AddLogCaptureStringV( const char *pFormat, va_list args ) = 0;
+	virtual void		AddLogCaptureStringF( const char *pFormat, ... ) = 0;
+	virtual void		unk201( void ) = 0;
 	virtual void		ExitMainLoop( void ) = 0;
+	virtual void		RegisterPrerequisite( IPrerequisite * ) = 0;
+	
+	// Same methods as ILocalize
+	virtual LocalizeStringIndex_t FindIndex(const char *tokenName) = 0;
+
+	// Same methods as IVEngineServer2 
+	virtual void		SetFrameTimeAmnesty( const char *amnesty, int, float frametime ) = 0;
+	virtual const char *GetFrameTimeAmnesty( bool check_cvar ) = 0;
+	virtual void		unk301() = 0;
+#ifdef _LINUX
+	virtual void		unk302() = 0;
+#endif
 };
 
 #endif // IENGINESERVICE_H

--- a/public/engine/IEngineService.h
+++ b/public/engine/IEngineService.h
@@ -96,14 +96,14 @@ public:
 	virtual void		RegisterPrerequisite( IPrerequisite * ) = 0;
 	
 	// Same methods as ILocalize
-	virtual LocalizeStringIndex_t FindLocalizeTokenIndex(const char *tokenName) = 0;
+	virtual LocalizeStringIndex_t LookupLocalizationToken(const char *tokenName) = 0;
 
 	// Same methods as IVEngineServer2 
 	virtual void		SetFrameTimeAmnesty( const char *amnesty, int, float frametime ) = 0;
 	virtual const char *GetFrameTimeAmnesty( bool check_cvar ) = 0;
 	virtual void		unk301() = 0;
 #ifdef _LINUX
-	virtual void		unk302() = 0;
+	virtual void		UnregisterPrerequisite( IPrerequisite * ) = 0;
 #endif
 };
 

--- a/public/engine/IEngineService.h
+++ b/public/engine/IEngineService.h
@@ -96,7 +96,7 @@ public:
 	virtual void		RegisterPrerequisite( IPrerequisite * ) = 0;
 	
 	// Same methods as ILocalize
-	virtual LocalizeStringIndex_t FindIndex(const char *tokenName) = 0;
+	virtual LocalizeStringIndex_t FindLocalizeTokenIndex(const char *tokenName) = 0;
 
 	// Same methods as IVEngineServer2 
 	virtual void		SetFrameTimeAmnesty( const char *amnesty, int, float frametime ) = 0;

--- a/public/iloopmode.h
+++ b/public/iloopmode.h
@@ -119,7 +119,6 @@ public:
 abstract_class ILoopModePrerequisiteRegistry : public IPrerequisiteRegistry
 {
 public:
-	virtual void LookupLocalizationToken( const char * ) = 0;
 	virtual void UnregisterPrerequisite( IPrerequisite * ) = 0;
 };
 

--- a/public/localize/ilocalize.h
+++ b/public/localize/ilocalize.h
@@ -17,7 +17,7 @@
 
 // unicode character type
 // for more unicode manipulation functions #include <wchar.h>
-#ifndef _WCHAR_T_DEFINED
+#if !defined(_WCHAR_T_DEFINED) && !defined(GNUC)
 typedef unsigned short wchar_t;
 #define _WCHAR_T_DEFINED
 #endif


### PR DESCRIPTION
There are a few things that should be looked into:
- Not too confident on `AddLogCaptureStringV/F` params and whether the name is appropriate for what they do.
- It seems strange to have two `RegisterPrerequisite` but I don't know how to make sense of it otherwise.
- `unk301` should be the same as `IVEngineServer2`'s `unk101`.
- `unk302` seems to only exists on Linux, I couldn't manage to find its equivalent in Windows for some reason.