### PR TITLE
Replace unsigned long with uint32 in bitbuf

### DIFF
--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -1056,12 +1056,12 @@ FORCEINLINE void StoreLittleDWord( unsigned long *base, unsigned int dwordIndex,
 			__storewordbytereverse( dword, dwordIndex<<2, base );
 		}
 #else
-FORCEINLINE unsigned long LoadLittleDWord( const unsigned long *base, unsigned int dwordIndex )
+FORCEINLINE unsigned long LoadLittleDWord( const uint32 *base, unsigned int dwordIndex )
 	{
 		return LittleDWord( base[dwordIndex] );
 	}
 
-FORCEINLINE void StoreLittleDWord( unsigned long *base, unsigned int dwordIndex, unsigned long dword )
+FORCEINLINE void StoreLittleDWord( uint32 *base, unsigned int dwordIndex, unsigned long dword )
 	{
 		base[dwordIndex] = LittleDWord(dword);
 	}

--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -1056,12 +1056,12 @@ FORCEINLINE void StoreLittleDWord( unsigned long *base, unsigned int dwordIndex,
 			__storewordbytereverse( dword, dwordIndex<<2, base );
 		}
 #else
-FORCEINLINE unsigned long LoadLittleDWord( const uint32 *base, unsigned int dwordIndex )
+FORCEINLINE uint32 LoadLittleDWord( const uint32 *base, unsigned int dwordIndex )
 	{
 		return LittleDWord( base[dwordIndex] );
 	}
 
-FORCEINLINE void StoreLittleDWord( uint32 *base, unsigned int dwordIndex, unsigned long dword )
+FORCEINLINE void StoreLittleDWord( uint32 *base, unsigned int dwordIndex, uint32 dword )
 	{
 		base[dwordIndex] = LittleDWord(dword);
 	}

--- a/public/tier1/bitbuf.h
+++ b/public/tier1/bitbuf.h
@@ -392,7 +392,7 @@ BITBUF_INLINE void bf_write::WriteUBitLong( unsigned int curData, int numbits, b
 	// Make sure it doesn't overflow.
 	if ( bCheckRange && numbits < 32 )
 	{
-		if ( curData >= (unsigned long)(1 << numbits) )
+		if ( curData >= (uint32)(1 << numbits) )
 		{
 			CallErrorHandler( BITBUFERROR_VALUE_OUT_OF_RANGE, GetDebugName() );
 		}
@@ -426,8 +426,8 @@ BITBUF_INLINE void bf_write::WriteUBitLong( unsigned int curData, int numbits, b
 	
 	// Only look beyond current word if necessary (avoid access violation)
 	int i = mask2 & 1;
-	unsigned long dword1 = LoadLittleDWord( pOut, 0 );
-	unsigned long dword2 = LoadLittleDWord( pOut, i );
+	uint32 dword1 = LoadLittleDWord( pOut, 0 );
+	uint32 dword2 = LoadLittleDWord( pOut, i );
 	
 	// Drop bits into place
 	dword1 ^= ( mask1 & ( curData ^ dword1 ) );
@@ -721,7 +721,7 @@ inline bool bf_read::CheckForOverflow(int nBits)
 inline int bf_read::ReadOneBitNoCheck()
 {
 #if VALVE_LITTLE_ENDIAN
-	unsigned int value = ((unsigned long * RESTRICT)m_pData)[m_iCurBit >> 5] >> (m_iCurBit & 31);
+	unsigned int value = ((uint32 * RESTRICT)m_pData)[m_iCurBit >> 5] >> (m_iCurBit & 31);
 #else
 	unsigned char value = m_pData[m_iCurBit >> 3] >> (m_iCurBit & 7);
 #endif

--- a/public/tier1/bitbuf.h
+++ b/public/tier1/bitbuf.h
@@ -255,7 +255,7 @@ public:
 
 public:
 	// The current buffer.
-	unsigned long* RESTRICT m_pData;
+	uint32* RESTRICT m_pData;
 	int				m_nDataBytes;
 	int				m_nDataBits;
 	
@@ -341,7 +341,7 @@ BITBUF_INLINE void bf_write::WriteOneBitNoCheck(int nValue)
 	else
 		m_pData[m_iCurBit >> 5] &= ~(1u << (m_iCurBit & 31));
 #else
-	extern unsigned long g_LittleBits[32];
+	extern uint32 g_LittleBits[32];
 	if(nValue)
 		m_pData[m_iCurBit >> 5] |= g_LittleBits[m_iCurBit & 31];
 	else
@@ -378,7 +378,7 @@ inline void	bf_write::WriteOneBitAt( int iBit, int nValue )
 	else
 		m_pData[iBit >> 5] &= ~(1u << (iBit & 31));
 #else
-	extern unsigned long g_LittleBits[32];
+	extern uint32 g_LittleBits[32];
 	if(nValue)
 		m_pData[iBit >> 5] |= g_LittleBits[iBit & 31];
 	else
@@ -414,7 +414,7 @@ BITBUF_INLINE void bf_write::WriteUBitLong( unsigned int curData, int numbits, b
 
 	// Mask in a dword.
 	Assert( (iDWord*4 + sizeof(long)) <= (unsigned int)m_nDataBytes );
-	unsigned long * RESTRICT pOut = &m_pData[iDWord];
+	uint32 * RESTRICT pOut = &m_pData[iDWord];
 
 	// Rotate data into dword alignment
 	curData = (curData << iCurBitMasked) | (curData >> (32 - iCurBitMasked));
@@ -789,12 +789,12 @@ BITBUF_INLINE unsigned int bf_read::ReadUBitLong( int numbits ) RESTRICT
 #if __i386__
 	unsigned int bitmask = (2 << (numbits-1)) - 1;
 #else
-	extern unsigned long g_ExtraMasks[33];
+	extern uint32 g_ExtraMasks[33];
 	unsigned int bitmask = g_ExtraMasks[numbits];
 #endif
 
-	unsigned int dw1 = LoadLittleDWord( (unsigned long* RESTRICT)m_pData, iWordOffset1 ) >> iStartBit;
-	unsigned int dw2 = LoadLittleDWord( (unsigned long* RESTRICT)m_pData, iWordOffset2 ) << (32 - iStartBit);
+	unsigned int dw1 = LoadLittleDWord( (uint32* RESTRICT)m_pData, iWordOffset1 ) >> iStartBit;
+	unsigned int dw2 = LoadLittleDWord( (uint32* RESTRICT)m_pData, iWordOffset2 ) << (32 - iStartBit);
 
 	return (dw1 | dw2) & bitmask;
 }

--- a/tier1/bitbuf.cpp
+++ b/tier1/bitbuf.cpp
@@ -83,14 +83,14 @@ void SetBitBufErrorHandler( BitBufErrorHandler fn )
 
 // #define BB_PROFILING
 
-unsigned long g_LittleBits[32];
+uint32 g_LittleBits[32];
 
 // Precalculated bit masks for WriteUBitLong. Using these tables instead of 
 // doing the calculations gives a 33% speedup in WriteUBitLong.
-unsigned long g_BitWriteMasks[32][33];
+uint32 g_BitWriteMasks[32][33];
 
 // (1 << i) - 1
-unsigned long g_ExtraMasks[33];
+uint32 g_ExtraMasks[33];
 
 class CBitWriteMasksInit
 {
@@ -152,12 +152,12 @@ void bf_write::StartWriting( void *pData, int nBytes, int iStartBit, int nBits )
 {
 	// Make sure it's dword aligned and padded.
 	Assert( (nBytes % 4) == 0 );
-	Assert(((unsigned long)pData & 3) == 0);
+	Assert(((uintp)pData & 3) == 0);
 
 	// The writing code will overrun the end of the buffer if it isn't dword aligned, so truncate to force alignment
 	nBytes &= ~3;
 
-	m_pData = (unsigned long*)pData;
+	m_pData = (uint32*)pData;
 	m_nDataBytes = nBytes;
 
 	if ( nBits == -1 )
@@ -462,7 +462,7 @@ bool bf_write::WriteBits(const void *pInData, int nBits)
 	}
 
 	// Align output to dword boundary
-	while (((unsigned long)pOut & 3) != 0 && nBitsLeft >= 8)
+	while (((uintp)pOut & 3) != 0 && nBitsLeft >= 8)
 	{
 
 		WriteUBitLong( *pOut, 8, false );
@@ -485,18 +485,18 @@ bool bf_write::WriteBits(const void *pInData, int nBits)
 	// X360TBD: Can't write dwords in WriteBits because they'll get swapped
 	if ( IsPC() && nBitsLeft >= 32 )
 	{
-		unsigned long iBitsRight = (m_iCurBit & 31);
-		unsigned long iBitsLeft = 32 - iBitsRight;
-		unsigned long bitMaskLeft = g_BitWriteMasks[iBitsRight][32];
-		unsigned long bitMaskRight = g_BitWriteMasks[0][iBitsRight];
+		uint32 iBitsRight = (m_iCurBit & 31);
+		uint32 iBitsLeft = 32 - iBitsRight;
+		uint32 bitMaskLeft = g_BitWriteMasks[iBitsRight][32];
+		uint32 bitMaskRight = g_BitWriteMasks[0][iBitsRight];
 
-		unsigned long *pData = &m_pData[m_iCurBit>>5];
+		uint32 *pData = &m_pData[m_iCurBit>>5];
 
 		// Read dwords.
 		while(nBitsLeft >= 32)
 		{
-			unsigned long curData = *(unsigned long*)pOut;
-			pOut += sizeof(unsigned long);
+			uint32 curData = *(uint32*)pOut;
+			pOut += sizeof(uint32);
 
 			*pData &= bitMaskLeft;
 			*pData |= curData << iBitsRight;
@@ -1440,7 +1440,7 @@ void bf_read::ExciseBits( int startbit, int bitstoremove )
 
 int bf_read::CompareBitsAt( int offset, bf_read * RESTRICT other, int otherOffset, int numbits ) RESTRICT
 {
-	extern unsigned long g_ExtraMasks[33];
+	extern uint32 g_ExtraMasks[33];
 
 	if ( numbits == 0 )
 		return 0;
@@ -1454,17 +1454,17 @@ int bf_read::CompareBitsAt( int offset, bf_read * RESTRICT other, int otherOffse
 
 	unsigned int iStartBit1 = offset & 31u;
 	unsigned int iStartBit2 = otherOffset & 31u;
-	unsigned long *pData1 = (unsigned long*)m_pData + (offset >> 5);
-	unsigned long *pData2 = (unsigned long*)other->m_pData + (otherOffset >> 5);
-	unsigned long *pData1End = pData1 + ((offset + numbits - 1) >> 5);
-	unsigned long *pData2End = pData2 + ((otherOffset + numbits - 1) >> 5);
+	uint32 *pData1 = (uint32*)m_pData + (offset >> 5);
+	uint32 *pData2 = (uint32*)other->m_pData + (otherOffset >> 5);
+	uint32 *pData1End = pData1 + ((offset + numbits - 1) >> 5);
+	uint32 *pData2End = pData2 + ((otherOffset + numbits - 1) >> 5);
 
 	while ( numbits > 32 )
 	{
-		x  = LoadLittleDWord( (unsigned long*)pData1, 0 ) >> iStartBit1;
-		x ^= LoadLittleDWord( (unsigned long*)pData1, 1 ) << (32 - iStartBit1);
-		x ^= LoadLittleDWord( (unsigned long*)pData2, 0 ) >> iStartBit2;
-		x ^= LoadLittleDWord( (unsigned long*)pData2, 1 ) << (32 - iStartBit2);
+		x  = LoadLittleDWord( (uint32*)pData1, 0 ) >> iStartBit1;
+		x ^= LoadLittleDWord( (uint32*)pData1, 1 ) << (32 - iStartBit1);
+		x ^= LoadLittleDWord( (uint32*)pData2, 0 ) >> iStartBit2;
+		x ^= LoadLittleDWord( (uint32*)pData2, 1 ) << (32 - iStartBit2);
 		if ( x != 0 )
 		{
 			return x; 
@@ -1474,9 +1474,9 @@ int bf_read::CompareBitsAt( int offset, bf_read * RESTRICT other, int otherOffse
 		numbits -= 32;
 	}
 
-	x  = LoadLittleDWord( (unsigned long*)pData1, 0 ) >> iStartBit1;
-	x ^= LoadLittleDWord( (unsigned long*)pData1End, 0 ) << (32 - iStartBit1);
-	x ^= LoadLittleDWord( (unsigned long*)pData2, 0 ) >> iStartBit2;
-	x ^= LoadLittleDWord( (unsigned long*)pData2End, 0 ) << (32 - iStartBit2);
+	x  = LoadLittleDWord( (uint32*)pData1, 0 ) >> iStartBit1;
+	x ^= LoadLittleDWord( (uint32*)pData1End, 0 ) << (32 - iStartBit1);
+	x ^= LoadLittleDWord( (uint32*)pData2, 0 ) >> iStartBit2;
+	x ^= LoadLittleDWord( (uint32*)pData2End, 0 ) << (32 - iStartBit2);
 	return x & g_ExtraMasks[ numbits ];
 }

--- a/tier1/bitbuf.cpp
+++ b/tier1/bitbuf.cpp
@@ -898,8 +898,8 @@ void bf_read::ReadBits(void *pOutData, int nBits)
 		// read dwords
 		while ( nBitsLeft >= 32 )
 		{
-			*((unsigned long*)pOut) = ReadUBitLong(32);
-			pOut += sizeof(unsigned long);
+			*((uint32*)pOut) = ReadUBitLong(32);
+			pOut += sizeof(uint32);
 			nBitsLeft -= 32;
 		}
 	}


### PR DESCRIPTION
This makes bf_write work properly on 64-bit platforms, and is the same as source-sdk-2013.

This requires tier1 to be rebuilt.