### PR TITLE
TF2: Fix tier1 not compiling with `/std:c++20` on msvc

### DIFF
--- a/public/tier1/UtlSortVector.h
+++ b/public/tier1/UtlSortVector.h
@@ -244,7 +244,7 @@ void CUtlSortVector<T, LessFunc, BaseVector>::QuickSort( LessFunc& less, int nLo
 		ctx.m_pLessContext = m_pLessContext;
 		ctx.m_pLessFunc = &less;
 
-		qsort_s( Base(), Count(), sizeof(T), (QSortCompareFunc_t)&CUtlSortVector<T, LessFunc>::CompareHelper, &ctx );
+		qsort_s( this->Base(), this->Count(), sizeof(T), (QSortCompareFunc_t)&CUtlSortVector<T, LessFunc>::CompareHelper, &ctx );
 	}
 #else
 	typedef int (__cdecl *QSortCompareFunc_t)( const void *, const void *);


### PR DESCRIPTION
MSVC wouldn't compile `public/tier1/UtlSortVector.h` with C++20

```
C:\Users\Eric Zhang\Documents\stuff\hl2sdk\public\tier1\UtlSortVector.h(247): error C3861: 'Base': identifier not found
C:\Users\Eric Zhang\Documents\stuff\hl2sdk\public\tier1\UtlSortVector.h(247): note: 'Base': function declaration must be available as none of the arguments depend on a template parameter
C:\Users\Eric Zhang\Documents\stuff\hl2sdk\public\tier1\UtlSortVector.h(247): error C3861: 'Count': identifier not found
C:\Users\Eric Zhang\Documents\stuff\hl2sdk\public\tier1\UtlSortVector.h(247): note: 'Count': function declaration must be available as none of the arguments depend on a template parameter
```

Not sure why this is the case, but the fix is simple enough. Might be the same case for other branches as well.