### PR TITLE
Update CGlobalVarsBase

### DIFF
--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -11,6 +11,8 @@
 #pragma once
 #endif
 
+#include "threadtools.h"
+
 enum GlobalVarsUsageWarning_t
 {
 	GV_RENDERTIME_CALLED_DURING_SIMULATION,
@@ -90,7 +92,7 @@ public:
 	// Simulation tick interval
 	float m_flIntervalPerTick;
 
-	unsigned long m_nThreadId; // ThreadId_t
+	ThreadId_t m_nThreadId;
 };
 
 inline CGlobalVarsBase::CGlobalVarsBase()

--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -90,7 +90,7 @@ public:
 	// Simulation tick interval
 	float m_flIntervalPerTick;
 
-	float unknown10;
+	unsigned long m_nThreadId; // ThreadId_t
 };
 
 inline CGlobalVarsBase::CGlobalVarsBase()


### PR DESCRIPTION
`unknown10` is set to the result of `GetCurrentThreadId()` right before movement processing.