### PR TITLE
Correct Schema_DynamicBinding offset in CEntityInstance

### DIFF
--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -139,7 +139,6 @@ public:
 	virtual void unk601() = 0;
 	virtual void unk602() = 0;
 
-	// Part of CBaseEntity
 	virtual SchemaMetaInfoHandle_t<CSchemaClassInfo> Schema_DynamicBinding() = 0;
 
 public:

--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -137,7 +137,9 @@ public:
 	virtual datamap_t* GetDataDescMap() = 0;
 
 	virtual void unk601() = 0;
+	virtual void unk602() = 0;
 
+	// Part of CBaseEntity
 	virtual SchemaMetaInfoHandle_t<CSchemaClassInfo> Schema_DynamicBinding() = 0;
 
 public:


### PR DESCRIPTION
Tested on Windows with the following code:

```c++
CON_COMMAND(schematest, "")
{
	EntityInstanceByClassIter_t iter(nullptr, "prop_dynamic");
	auto ent = iter.First();
	if (ent)
	{
		auto schemabinding = ent->Schema_DynamicBinding().Get();
		Msg("%s\n", schemabinding->m_pDeclaredClass->m_pClassInfo->m_pszName); // Should say "CDynamicProp"
	}
}
```