### PR TITLE
Update: fix vector cast warning

### DIFF
--- a/public/mathlib/vector.h
+++ b/public/mathlib/vector.h
@@ -665,9 +665,9 @@ inline void Vector::Init( vec_t ix, vec_t iy, vec_t iz )
 
 inline void Vector::Random( vec_t minVal, vec_t maxVal )
 {
-	x = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	y = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	z = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
+	x = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	y = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	z = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
 	CHECK_VALID(*this);
 }
 
@@ -2124,9 +2124,9 @@ inline void QAngle::Init( vec_t ix, vec_t iy, vec_t iz )
 
 inline void QAngle::Random( vec_t minVal, vec_t maxVal )
 {
-	x = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	y = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	z = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
+	x = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	y = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	z = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
 	CHECK_VALID(*this);
 }
 

--- a/public/mathlib/vector2d.h
+++ b/public/mathlib/vector2d.h
@@ -239,8 +239,8 @@ inline void Vector2D::Init( vec_t ix, vec_t iy )
 
 inline void Vector2D::Random( float minVal, float maxVal )
 {
-	x = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
-	y = minVal + ((float)rand() / RAND_MAX) * (maxVal - minVal);
+	x = minVal + (static_cast<float>(rand()) / static_cast<float>(RAND_MAX)) * (maxVal - minVal);
+	y = minVal + (static_cast<float>(rand()) / static_cast<float>(RAND_MAX)) * (maxVal - minVal);
 }
 
 inline void Vector2DClear( Vector2D& a )

--- a/public/mathlib/vector4d.h
+++ b/public/mathlib/vector4d.h
@@ -260,10 +260,10 @@ inline void Vector4D::Init( const Vector& src, vec_t iw )
 
 inline void Vector4D::Random( vec_t minVal, vec_t maxVal )
 {
-	x = minVal + ((vec_t)rand() / RAND_MAX) * (maxVal - minVal);
-	y = minVal + ((vec_t)rand() / RAND_MAX) * (maxVal - minVal);
-	z = minVal + ((vec_t)rand() / RAND_MAX) * (maxVal - minVal);
-	w = minVal + ((vec_t)rand() / RAND_MAX) * (maxVal - minVal);
+	x = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	y = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	z = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
+	w = minVal + (static_cast<vec_t>(rand()) / static_cast<vec_t>(RAND_MAX)) * (maxVal - minVal);
 }
 
 inline void Vector4DClear( Vector4D& a )


### PR DESCRIPTION
Fixes clang18 build warning with implicit cast of max int to float, now casts to vec_t