### PR TITLE
Fix vscript variant EHANDLE conversions

### DIFF
--- a/public/vscript/variant.h
+++ b/public/vscript/variant.h
@@ -129,8 +129,8 @@ public:
 	operator char() const					{ Assert( m_type == FIELD_CHARACTER );	return m_char; }
 	operator bool() const					{ Assert( m_type == FIELD_BOOLEAN );	return m_bool; }
 	operator HSCRIPT() const				{ Assert( m_type == FIELD_HSCRIPT );	return m_hScript; }
-	operator CBaseHandle() const			{ Assert( m_type == FIELD_EHANDLE );	return CBaseHandle( m_hEntity ); }
-        operator CBaseEntity*() const				{ Assert( m_type == FIELD_EHANDLE );    return CHandle<CBaseEntity>(CBaseHandle( m_hEntity )); }
+	operator CBaseHandle() const			{ Assert( m_type == FIELD_EHANDLE );	return CBaseHandle::UnsafeFromIndex( m_hEntity ); }
+        operator CBaseEntity*() const				{ Assert( m_type == FIELD_EHANDLE );    return CHandle<CBaseEntity>::UnsafeFromIndex( m_hEntity ); }
 	operator const Quaternion &() const		{ Assert( m_type == FIELD_QUATERNION );	return m_pData ? *(Quaternion*)m_pData : quat_identity; }
 //	operator CUtlStringToken() const		{ Assert( m_type == FIELD_UTLSTRINGTOKEN );	CUtlStringToken t; t.m_nHashCode = m_utlStringToken; return t; }
 
@@ -614,7 +614,7 @@ inline bool CVariantBase<CValueAllocator>::AssignTo( CBaseHandle *pDest ) const
 {
 	switch( m_type )
 	{
-	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >(m_hEntity); return true;
+	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >::UnsafeFromIndex( m_hEntity ); return true;
 	default:
 		Warning( "No free conversion of %s variant to EHANDLE right now\n", VariantFieldTypeName( m_type ) );
 		break;
@@ -627,7 +627,7 @@ inline bool CVariantBase<CValueAllocator>::AssignTo( CBaseEntity **pDest ) const
 {
 	switch( m_type )
 	{
-	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >(m_hEntity); return true;
+	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >::UnsafeFromIndex( m_hEntity ); return true;
 	default:
 		Warning( "No free conversion of %s variant to CBaseEntity * right now\n", VariantFieldTypeName( m_type ) );
 		break;


### PR DESCRIPTION
a0d9a0f9 synced the hl2sdk with the Source SDK 2013. Unfortunately, this reverted a SourceMod-specific hack that was introduced in another sync commit:

https://github.com/alliedmodders/hl2sdk/blob/ebd971b42177ba73ca25a05f33551fa2005525b6/public/basehandle.h#L36-L37

This being reverted now causes compilation errors for any extension relying on it. One case I ran into is the vscript CVariantBase. However, instead of restoring the hack, I'd rather just fix the SDK bug.

I have submitted the same fix to the Source SDK 2013 repo: https://github.com/ValveSoftware/source-sdk-2013/pull/1948