### PR TITLE
tf2: Clarify use of overload CUtlSymbolTable::Find

### DIFF
--- a/public/tier1/utlsymbol.h
+++ b/public/tier1/utlsymbol.h
@@ -105,7 +105,7 @@ public:
 	
 	inline bool HasElement( const char* pStr ) const
 	{
-		return Find( pStr ) != UTL_INVAL_SYMBOL;
+		return (UtlSymId_t)(Find( pStr )) != UTL_INVAL_SYMBOL;
 	}
 
 	// Remove all symbols in the table.


### PR DESCRIPTION
Same as #352. It was reverted by a0d9a0f9e684a25b505e7d86d36cb514e0bd17df.