### PR TITLE
Fixed an implicit issue with using the legacy old_bf_read class.

### DIFF
--- a/public/tier1/bitbuf.h
+++ b/public/tier1/bitbuf.h
@@ -1491,6 +1491,7 @@ public:
 };
 #endif
 
+WRAP_READ( CBitRead );
 WRAP_WRITE( old_bf_write );
 
 #endif

--- a/public/tier1/bitbuf.h
+++ b/public/tier1/bitbuf.h
@@ -1493,7 +1493,7 @@ public:
 
 
 #if defined _LINUX || defined __APPLE__
-WRAP_READ( old_bf_read );
+WRAP_READ( CBitRead );
 #else
 WRAP_READ( CBitRead );
 #endif

--- a/public/tier1/bitbuf.h
+++ b/public/tier1/bitbuf.h
@@ -1491,16 +1491,6 @@ public:
 };
 #endif
 
-
-#if defined _LINUX || defined __APPLE__
-WRAP_READ( CBitRead );
-#else
-WRAP_READ( CBitRead );
-#endif
 WRAP_WRITE( old_bf_write );
 
-
 #endif
-
-
-


### PR DESCRIPTION
I don't know what the SDK should look like in this case, so I'll make a simple fix. The problem is that when compiling code with the bf_read alias, the old_bf_read class is used, even though the game only uses the CBitRead class. This creates coding issues and subtle data reading problems. If you explicitly specify the CBitRead class, the code starts working correctly, but if hl2sdk-l4d2 contains structures with bf_read fields, it also breaks, requiring you to manually read this field.