### PR TITLE
[CS2] Fix INetworkGameServer, Add ServerEndSimulate.

### DIFF
--- a/public/iserver.h
+++ b/public/iserver.h
@@ -33,6 +33,7 @@ struct EventServerAdvanceTick_t;
 struct EventServerPollNetworking_t;
 struct EventServerProcessNetworking_t;
 struct EventServerSimulate_t;
+struct EventServerEndSimulate_t;
 struct EventServerPostSimulate_t;
 struct SpawnGroupDesc_t;
 class IPrerequisite;
@@ -74,13 +75,12 @@ public:
 	// returns current client limit
 	virtual int		GetMaxClients( void ) const = 0;
 
-	virtual float   unk001() = 0;
-
 	virtual void	ServerAdvanceTick( const EventServerAdvanceTick_t & ) = 0;
 	virtual void	ServerPollNetworking( const EventServerPollNetworking_t & ) = 0;
 	virtual void	ServerProcessNetworking( const EventServerProcessNetworking_t & ) = 0;
 
 	virtual void	ServerSimulate( const EventServerSimulate_t & ) = 0;
+	virtual void	ServerEndSimulate( const EventServerEndSimulate_t & ) = 0;
 	virtual void	ServerPostSimulate( const EventServerPostSimulate_t & ) = 0;
 
 	virtual SpawnGroupHandle_t LoadSpawnGroup( const SpawnGroupDesc_t & ) = 0;


### PR DESCRIPTION
## Evidence of `INetworkGameServer::ServerEndSimulate`

<img width="573" height="450" alt="Screenshot 2026-07-08 150826" src="https://github.com/user-attachments/assets/300480ce-235f-4ef2-9066-eed8aa132cc9" />

<img width="669" height="137" alt="Screenshot 2026-07-08 150806" src="https://github.com/user-attachments/assets/5a011cef-20e2-4d18-9650-b6975e2a5892" />

<img width="803" height="373" alt="Screenshot 2026-07-08 150717" src="https://github.com/user-attachments/assets/cd293fdc-46f1-48a0-a3e9-ccd0e186e703" />

136LL= vtable[17]

## Evidence of `INetworkGameServer::ServerAdvanceTick`

<img width="604" height="301" alt="image" src="https://github.com/user-attachments/assets/85e6d070-97b8-4a29-a15b-241ee78b96b9" />

<img width="470" height="155" alt="image" src="https://github.com/user-attachments/assets/6d229258-1a32-46ec-bf89-c3821945b258" />

104LL = vtable[13]

## Evidence of `INetworkGameServer::GetMaxClients`

<img width="644" height="417" alt="image" src="https://github.com/user-attachments/assets/a118b647-1484-449f-b37d-8cb9df4878c0" />

96LL = vtable[12]

<img width="294" height="278" alt="image" src="https://github.com/user-attachments/assets/c62f6300-f379-459c-9437-399c82dfb1ce" />

