### PR TITLE
Update CS2 SDK for server 2000872 ABI changes

### DIFF
--- a/game/shared/igamesystem.h
+++ b/game/shared/igamesystem.h
@@ -345,7 +345,7 @@ public:
 	GS_EVENT_IMPL( ServerPostAdvanceTick )					// 39
 	GS_EVENT_IMPL( ClientPostAdvanceTick )					// 40
 
-	virtual void unk_102( const void *const msg ) = 0;		// 41
+	virtual void unk_201( const void *const msg ) = 0;		// 41
 
 	GS_EVENT_IMPL( ServerBeginAsyncPostTickWork )			// 42
 	GS_EVENT_IMPL( ServerPreEndAsyncPostTickWork )			// 43
@@ -364,11 +364,11 @@ public:
 	GS_EVENT_IMPL( NewLevelPlayerConnect )					// 52
 
 	// AMNOTE: CSpawnGroupMgrGameSystem related
-	virtual void unk_201( const void *const msg ) = 0;		// 53
-	virtual void unk_202( const void *const msg ) = 0;		// 54
+	virtual void unk_301( const void *const msg ) = 0;		// 53
+	virtual void unk_302( const void *const msg ) = 0;		// 54
 
-	virtual void unk_203( const void *const msg ) = 0;		// 55
-	virtual void unk_204( const void *const msg ) = 0;		// 56
+	virtual void unk_303( const void *const msg ) = 0;		// 55
+	virtual void unk_304( const void *const msg ) = 0;		// 56
 
 	// Same as to demo_skip event
 	GS_EVENT_IMPL( DemoSkip )								// 57
@@ -459,8 +459,8 @@ public:
 	GS_EVENT( ServerPostAdvanceTick ) {}
 	GS_EVENT( ClientPostAdvanceTick ) {}
 
-	virtual void unk_102( const void *const msg ) override {}
-	
+	virtual void unk_201( const void *const msg ) override {}
+
 	GS_EVENT( ServerBeginAsyncPostTickWork ) {}
 	GS_EVENT( ServerPreEndAsyncPostTickWork ) {}
 	GS_EVENT( ServerPostEndAsyncPostTickWork ) {}
@@ -476,10 +476,10 @@ public:
 
 	GS_EVENT( NewLevelPlayerConnect ) {}
 
-	virtual void unk_201( const void *const msg ) override {}
-	virtual void unk_202( const void *const msg ) override {}
-	virtual void unk_203( const void *const msg ) override {}
-	virtual void unk_204( const void *const msg ) override {}
+	virtual void unk_301( const void *const msg ) override {}
+	virtual void unk_302( const void *const msg ) override {}
+	virtual void unk_303( const void *const msg ) override {}
+	virtual void unk_304( const void *const msg ) override {}
 
 	GS_EVENT( DemoSkip ) {}
 

--- a/game/shared/igamesystem.h
+++ b/game/shared/igamesystem.h
@@ -344,38 +344,41 @@ public:
 	GS_EVENT_IMPL( ClientGamePostSimulate )					// 38
 	GS_EVENT_IMPL( ServerPostAdvanceTick )					// 39
 	GS_EVENT_IMPL( ClientPostAdvanceTick )					// 40
-	GS_EVENT_IMPL( ServerBeginAsyncPostTickWork )			// 41
-	GS_EVENT_IMPL( ServerPreEndAsyncPostTickWork )			// 42
-	GS_EVENT_IMPL( ServerPostEndAsyncPostTickWork )			// 43
-	GS_EVENT_IMPL( ClientFrameSimulate )					// 44
-	GS_EVENT_IMPL( ClientPauseSimulate )					// 45
-	GS_EVENT_IMPL( ClientAdvanceNonRenderedFrame )			// 46
 
-	GS_EVENT_IMPL( GameFrameBoundary )						// 47
-	GS_EVENT_IMPL( OutOfGameFrameBoundary )					// 48
+	virtual void unk_102( const void *const msg ) = 0;		// 41
 
-	GS_EVENT_IMPL( SaveGame )								// 49
-	GS_EVENT_IMPL( RestoreGame )							// 50
+	GS_EVENT_IMPL( ServerBeginAsyncPostTickWork )			// 42
+	GS_EVENT_IMPL( ServerPreEndAsyncPostTickWork )			// 43
+	GS_EVENT_IMPL( ServerPostEndAsyncPostTickWork )			// 44
+	GS_EVENT_IMPL( ClientFrameSimulate )					// 45
+	GS_EVENT_IMPL( ClientPauseSimulate )					// 46
+	GS_EVENT_IMPL( ClientAdvanceNonRenderedFrame )			// 47
+
+	GS_EVENT_IMPL( GameFrameBoundary )						// 48
+	GS_EVENT_IMPL( OutOfGameFrameBoundary )					// 49
+
+	GS_EVENT_IMPL( SaveGame )								// 50
+	GS_EVENT_IMPL( RestoreGame )							// 51
 
 	// AMNOTE: Called only when gpGlobals->maxplayer == 1 on player_connect_full
-	GS_EVENT_IMPL( NewLevelPlayerConnect )					// 51
+	GS_EVENT_IMPL( NewLevelPlayerConnect )					// 52
 
 	// AMNOTE: CSpawnGroupMgrGameSystem related
-	virtual void unk_201( const void *const msg ) = 0;		// 52
-	virtual void unk_202( const void *const msg ) = 0;		// 53
+	virtual void unk_201( const void *const msg ) = 0;		// 53
+	virtual void unk_202( const void *const msg ) = 0;		// 54
 
-	virtual void unk_203( const void *const msg ) = 0;		// 54
-	virtual void unk_204( const void *const msg ) = 0;		// 55
+	virtual void unk_203( const void *const msg ) = 0;		// 55
+	virtual void unk_204( const void *const msg ) = 0;		// 56
 
 	// Same as to demo_skip event
-	GS_EVENT_IMPL( DemoSkip )								// 56
+	GS_EVENT_IMPL( DemoSkip )								// 57
 
-	GS_EVENT_IMPL( PrePackEntities )						// 57
+	GS_EVENT_IMPL( PrePackEntities )						// 58
 
-	virtual const char* GetName() const = 0;				// 58
-	virtual void SetGameSystemGlobalPtrs(void* pValue) = 0;	// 59
-	virtual void SetName(const char* pName) = 0;			// 60
-	virtual bool DoesGameSystemReallocate() = 0;			// 61
+	virtual const char* GetName() const = 0;				// 59
+	virtual void SetGameSystemGlobalPtrs(void* pValue) = 0;	// 60
+	virtual void SetName(const char* pName) = 0;			// 61
+	virtual bool DoesGameSystemReallocate() = 0;			// 62
 	virtual ~IGameSystem() {}
 	virtual void YouForgot_DECLARE_GAME_SYSTEM_InYourClassDefinition() = 0;
 };
@@ -455,6 +458,9 @@ public:
 	GS_EVENT( ClientGamePostSimulate ) {}
 	GS_EVENT( ServerPostAdvanceTick ) {}
 	GS_EVENT( ClientPostAdvanceTick ) {}
+
+	virtual void unk_102( const void *const msg ) override {}
+	
 	GS_EVENT( ServerBeginAsyncPostTickWork ) {}
 	GS_EVENT( ServerPreEndAsyncPostTickWork ) {}
 	GS_EVENT( ServerPostEndAsyncPostTickWork ) {}

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -230,10 +230,6 @@ public:
 	// Issue the specified command to the specified client (mimics that client typing the command at the console).
 	virtual void		ClientCommand( CPlayerSlot nSlot, const char *szFmt, ... ) FMTFUNCTION( 3, 4 ) = 0;
 
-	// Set the lightstyle to the specified value and network the change to any connected clients.  Note that val must not
-	//  change place in memory (use MAKE_STRING) for anything that's not compiled into your mod.
-	virtual void		LightStyle( int style, const char *val ) = 0;
-
 	// Print szMsg to the client console.
 	virtual void		ClientPrintf( CPlayerSlot nSlot, const char *szMsg ) = 0;
 

--- a/public/icvar.h
+++ b/public/icvar.h
@@ -71,7 +71,7 @@ public:
 	virtual ConVarRef		FindFirstConVar() = 0;
 	virtual ConVarRef		FindNextConVar( ConVarRef prev ) = 0;
 
-	virtual void			CallChangeCallback( ConVarRef cvar, const CSplitScreenSlot nSlot, const CVValue_t* pNewValue, const CVValue_t* pOldValue, void *__unk01 = nullptr ) = 0;
+	virtual void			CallChangeCallback( ConVarRef cvar, const CSplitScreenSlot nSlot, const CVValue_t *pNewValue, const CVValue_t *pOldValue, void *__unk01 = nullptr ) = 0;
 	// Would call cb for every change callback defined for this cvar
 	virtual void			IterateConVarCallbacks( ConVarRef cvar, FnCvarCallbacksReader_t cb ) = 0;
 	// If returns false value shouldn't be modified
@@ -86,19 +86,17 @@ public:
 	// Install a global change callback (to be called when any convar changes) 
 	virtual void			InstallGlobalChangeCallback( FnChangeCallbackGlobal_t callback ) = 0;
 	virtual void			RemoveGlobalChangeCallback( FnChangeCallbackGlobal_t callback ) = 0;
-	virtual void			CallGlobalChangeCallbacks( ConVarRefAbstract* ref, CSplitScreenSlot nSlot, const char* newValue, const char* oldValue, void *__unk01 = nullptr ) = 0;
+	virtual void			CallGlobalChangeCallbacks( ConVarRefAbstract *ref, CSplitScreenSlot nSlot, const char *newValue, const char *oldValue, void *__unk01 = nullptr ) = 0;
 
 	// Reverts cvars to default values which contain a specific flag,
 	// cvars with a flag FCVAR_COMMANDLINE_ENFORCED would be skipped
 	virtual void			ResetConVarsToDefaultValuesByFlag( uint64 nFlag ) = 0;
 
 	virtual void			SetMaxSplitScreenSlots( int nSlots ) = 0;
-	virtual int				GetMaxSplitScreenSlots() const = 0;
+	int						GetMaxSplitScreenSlots() const { return m_MaxSplitScreenSlots; }
 
 	virtual void			RegisterCreationListeners( IConVarListener *callbacks ) = 0;
 	virtual void			RemoveCreationListeners( IConVarListener *callbacks ) = 0;
-
-	virtual void			unk001() = 0;
 
 	// Reverts cvars to default values which match pszPrefix string,
 	// ignores FCVAR_COMMANDLINE_ENFORCED
@@ -148,6 +146,9 @@ public:
 
 	// Queues up value (creates a copy of it) to be set when convar is ready to be edited
 	virtual void				QueueThreadSetValue( ConVarRefAbstract* ref, CSplitScreenSlot nSlot, void* __unk01, CVValue_t* value ) = 0;
+
+private:
+	int m_MaxSplitScreenSlots;
 };
 
 #include "memdbgon.h"
@@ -271,8 +272,6 @@ public:
 	CUtlHashtable<CUtlStringToken, uint16> m_ConCommandHashes;
 	CUtlLinkedList<ConCommandCallbackInfoNode_t, unsigned short, true> m_CallbackInfoList;
 	int m_ConCommandCount;
-
-	int m_SplitScreenSlots;
 
 	CAtomicMutex m_Mutex;
 	characterset_t m_CharacterSet;

--- a/public/tier1/utlstringtoken.h
+++ b/public/tier1/utlstringtoken.h
@@ -24,7 +24,6 @@ class CFormatStringElement;
 
 // AMNOTE: See VStringTokenSystem001
 // Interact with stringtokendatabase.txt
-PLATFORM_INTERFACE bool g_bUpdateStringTokenDatabase;
 PLATFORM_INTERFACE void RegisterStringToken( uint32 nHashCode, const char *pStart, const char *pEnd = NULL, bool bExtraAddToDatabase = true );
 
 class CUtlStringToken
@@ -36,10 +35,6 @@ public:
 		if(str && *str)
 		{
 			m_nHashCode = MurmurHash2LowerCase( str, STRINGTOKEN_MURMURHASH_SEED );
-			if(g_bUpdateStringTokenDatabase)
-			{
-				RegisterStringToken( m_nHashCode, str, 0, true );
-			}
 		}
 	}
 


### PR DESCRIPTION
This is a small CS2 SDK update for the latest dedicated server build I have on my server:

- server/client version: `2000872`
- patch version: `1.41.6.8`

I hit the same Metamod breakage people are seeing after the update, then used the newer SDK layout changes as a starting point and tested the result on a live Linux CS2 server.

What this fixes for me:

- Metamod no longer fails with `undefined symbol: g_bUpdateStringTokenDatabase`.
- The `ICvar` vtable offset is back in the right place for `ConVar_Register` / `metamod_version` registration.
- Metamod gets the right game/addons path again and can discover plugin VDFs.
- CounterStrikeSharp can be rebuilt against this SDK without the obsolete stringtoken imports.

What I changed here:

- removed the old stringtoken database usage path
- updated `IGameSystem`
- updated `ICvar`
- updated `IVEngineServer2`

I tested this by rebuilding both Metamod:Source and CounterStrikeSharp `v1.0.370` against this branch, then deploying both binaries to a live CS2 dedicated server.

After deploy, and again after a clean `docker restart cs2`, I saw:

- `[META] Loaded 1 plugin`
- `CounterStrikeSharp.API Loaded Successfully`
- my CSS plugin started and exposed its HTTP endpoint
- plugin health returned `status=ok` and `nativeAuthAvailable=true`
- server state returned `loggedOnToSteam=true`, `vacSecure=true`, `mapTimelimitMinutes=60`, `mapTimeLeftSource=mp_timelimit`

One thing this does not fix: CounterStrikeSharp still logs missing gamedata signatures for `Host_Say`, `CEntityInstance_AcceptInput`, and `CBaseEntity_TakeDamageOld`. Those did not block CSS startup or my plugin flow, but they probably need a separate CSS gamedata/signature update.
