### PR TITLE
Fix vscript variant compile under clang-22

### DIFF
--- a/public/vscript/variant.h
+++ b/public/vscript/variant.h
@@ -264,7 +264,7 @@ DECLARE_DEDUCE_FIELDTYPE( FIELD_QUATERNION,	Quaternion );
 DECLARE_DEDUCE_FIELDTYPE( FIELD_QUATERNION,	const Quaternion & );
 //DECLARE_DEDUCE_FIELDTYPE( FIELD_UTLSTRINGTOKEN,	CUtlStringToken );
 
-#define VariantDeduceType( T ) ((fieldtype_t)VariantDeducer_t<T>::FIELD_TYPE)
+#define VariantDeduceType( T ) ((ExtendedFieldType_t)VariantDeducer_t<T>::FIELD_TYPE)
 
 template <typename T>
 inline const char * VariantFieldTypeName() 


### PR DESCRIPTION
Follow-up to #390.

SDK bug: `VariantDeduceType` casts extended field types (e.g. `FIELD_QANGLE` = 39) to `fieldtype_t`, whose valid range is only 0-31. clang-21 and above reject this whenever `CopyData`'s `COMPILE_TIME_ASSERT` is instantiated, e.g. via the `ScriptVariant_t` copy constructor.

This affects `tf2`, `css`, `hl2dm` & `dods` branches in this repo and should be cherry-picked when merged.