### PR TITLE
Split CUtlOrderedMap into CUtlOrderedMapBase, expand map methods

### DIFF
--- a/public/tier1/utlmap.h
+++ b/public/tier1/utlmap.h
@@ -31,8 +31,18 @@
 #define FOR_EACH_MAP_FAST( mapName, iteratorName ) \
 	for ( int iteratorName = 0; iteratorName < mapName.MaxElement(); ++iteratorName ) if ( !mapName.IsValidIndex( iteratorName ) ) continue; else
 
-template <typename K, typename T, typename LF = CDefLess<K>, typename I = int>
-class CUtlOrderedMap
+struct base_utlmap_t
+{
+public:
+	// Marker so map types can be identified at compile time
+	enum
+	{
+		IsUtlMap = true
+	};
+};
+
+template <typename K, typename T, typename LF, typename I = int>
+class CUtlOrderedMapBase : public base_utlmap_t
 {
 public:
 	typedef K KeyType_t;
@@ -47,13 +57,8 @@ public:
 	// Left at growSize = 0, the memory will first allocate 1 element and double in size
 	// at each increment.
 	// LessFunc_t is required, but may be set after the constructor using SetLessFunc() below
-	CUtlOrderedMap( int growSize = 0, int initSize = 0, LessFunc_t lessfunc = 0 )
+	CUtlOrderedMapBase( int growSize, int initSize, const LessFunc_t &lessfunc )
 	 : m_Tree( growSize, initSize, CKeyLess( lessfunc ) )
-	{
-	}
-
-	CUtlOrderedMap( LessFunc_t lessfunc )
-	 : m_Tree( CKeyLess( lessfunc ) )
 	{
 	}
 	
@@ -70,6 +75,8 @@ public:
 	
 	// Num elements
 	unsigned int Count() const								{ return m_Tree.Count(); }
+
+	bool IsEmpty() const									{ return Count() == 0; }
 	
 	// Max "size" of the vector
 	IndexType_t  MaxElement() const							{ return m_Tree.MaxElement(); }
@@ -105,6 +112,46 @@ public:
 		return m_Tree.Insert( node );
 	}
 
+	// Returns the existing index if the key is already present
+	IndexType_t InsertIfNotFound( const KeyType_t &key, const ElemType_t &insert )
+	{
+		Node_t node;
+		node.key = key;
+		node.elem = insert;
+		return m_Tree.InsertIfNotFound( node );
+	}
+
+	// pInserted reports whether an insert happened
+	IndexType_t FindOrInsert( const KeyType_t &key, const ElemType_t &insert, bool *pInserted = NULL )
+	{
+		IndexType_t i = Find( key );
+		if ( i != InvalidIndex() )
+		{
+			if ( pInserted )
+				*pInserted = false;
+			return i;
+		}
+
+		if ( pInserted )
+			*pInserted = true;
+		return Insert( key, insert );
+	}
+
+	IndexType_t FindOrInsertDefault( const KeyType_t &key, bool *pInserted = NULL )
+	{
+		return FindOrInsert( key, ElemType_t(), pInserted );
+	}
+
+	ElemType_t *FindOrInsertGetPtr( const KeyType_t &key, const ElemType_t &insert, bool *pInserted = NULL )
+	{
+		return &Element( FindOrInsert( key, insert, pInserted ) );
+	}
+
+	ElemType_t *FindOrInsertDefaultGetPtr( const KeyType_t &key, bool *pInserted = NULL )
+	{
+		return &Element( FindOrInsertDefault( key, pInserted ) );
+	}
+
 	// Find method
 	IndexType_t  Find( const KeyType_t &key ) const
 	{
@@ -112,6 +159,36 @@ public:
 		dummyNode.key = key;
 		return m_Tree.Find( dummyNode );
 	}
+
+	const ElemType_t &FindElement( const KeyType_t &key ) const
+	{
+		return Element( Find( key ) );
+	}
+
+	// By value, so a temporary defaultValue is safe
+	ElemType_t FindElement( const KeyType_t &key, const ElemType_t &defaultValue ) const
+	{
+		IndexType_t i = Find( key );
+		if ( i == InvalidIndex() )
+			return defaultValue;
+		return Element( i );
+	}
+
+	// NULL when the key isn't present
+	ElemType_t *FindGetPtr( const KeyType_t &key )
+	{
+		IndexType_t i = Find( key );
+		return i == InvalidIndex() ? NULL : &Element( i );
+	}
+
+	const ElemType_t *FindGetPtr( const KeyType_t &key ) const
+	{
+		IndexType_t i = Find( key );
+		return i == InvalidIndex() ? NULL : &Element( i );
+	}
+
+	bool HasElement( const KeyType_t &key ) const			{ return Find( key ) != InvalidIndex(); }
+	bool HasKey( const KeyType_t &key ) const				{ return Find( key ) != InvalidIndex(); }
 	
 	// Remove methods
 	void     RemoveAt( IndexType_t i )						{ m_Tree.RemoveAt( i ); }
@@ -124,6 +201,27 @@ public:
 	
 	void     RemoveAll( )									{ m_Tree.RemoveAll(); }
 	void     Purge( )										{ m_Tree.Purge(); }
+
+	// Only valid when ElemType_t is a pointer
+	void PurgeAndDeleteElements()
+	{
+		for ( IndexType_t i = 0; i < MaxElement(); ++i )
+		{
+			if ( IsValidIndex( i ) )
+				delete Element( i );
+		}
+		Purge();
+	}
+
+	void RemoveAllAndDeleteElements()
+	{
+		for ( IndexType_t i = 0; i < MaxElement(); ++i )
+		{
+			if ( IsValidIndex( i ) )
+				delete Element( i );
+		}
+		RemoveAll();
+	}
 			
 	// Iteration
 	IndexType_t  FirstInorder() const						{ return m_Tree.FirstInorder(); }
@@ -151,9 +249,20 @@ public:
 		return Insert( key, insert );
 	}
 
-	void Swap( CUtlOrderedMap< K, T, LF, I > &that )
+	void Swap( CUtlOrderedMapBase< K, T, LF, I > &that )
 	{
 		m_Tree.Swap( that.m_Tree );
+	}
+
+	void CopyFrom( const CUtlOrderedMapBase< K, T, LF, I > &other )
+	{
+		m_Tree.CopyFrom( other.m_Tree );
+	}
+
+	CUtlOrderedMapBase< K, T, LF, I > &operator=( const CUtlOrderedMapBase< K, T, LF, I > &other )
+	{
+		CopyFrom( other );
+		return *this;
 	}
 
 
@@ -197,6 +306,24 @@ public:
 
 protected:
 	CTree 	   m_Tree;
+};
+
+// Adds the default LessFunc and index type. Storage and logic live in the base.
+template <typename K, typename T, typename LF = CDefLess<K>, typename I = int>
+class CUtlOrderedMap : public CUtlOrderedMapBase< K, T, LF, I >
+{
+public:
+	typedef CUtlOrderedMapBase< K, T, LF, I > BaseClass;
+
+	CUtlOrderedMap( int growSize, int initSize, const LF &lessfunc = LF() )
+	 : BaseClass( growSize, initSize, lessfunc )
+	{
+	}
+
+	CUtlOrderedMap( const LF &lessfunc = LF() )
+	 : BaseClass( 0, 0, lessfunc )
+	{
+	}
 };
 
 #endif // UTLMAP_H

--- a/public/tier1/utlmap.h
+++ b/public/tier1/utlmap.h
@@ -25,19 +25,23 @@
 
 // This is a useful macro to iterate from start to end in order in a map
 #define FOR_EACH_MAP( mapName, iteratorName ) \
-	for ( int iteratorName = mapName.FirstInorder(); iteratorName != mapName.InvalidIndex(); iteratorName = mapName.NextInorder( iteratorName ) )
+	for ( int iteratorName = (mapName).FirstInorder(); (mapName).IsUtlMap && iteratorName != (mapName).InvalidIndex(); iteratorName = (mapName).NextInorder( iteratorName ) )
 
 // faster iteration, but in an unspecified order
 #define FOR_EACH_MAP_FAST( mapName, iteratorName ) \
-	for ( int iteratorName = 0; iteratorName < mapName.MaxElement(); ++iteratorName ) if ( !mapName.IsValidIndex( iteratorName ) ) continue; else
+	for ( int iteratorName = 0; (mapName).IsUtlMap && iteratorName < (mapName).MaxElement(); ++iteratorName ) if ( !(mapName).IsValidIndex( iteratorName ) ) continue; else
 
 struct base_utlmap_t
 {
 public:
-	// Marker so map types can be identified at compile time
-	enum
+	// This enum exists so that FOR_EACH_MAP and FOR_EACH_MAP_FAST cannot accidentally
+	// be used on a type that is not a CUtlOrderedMapBase. If the code compiles then all is well.
+	// The check for IsUtlMap being true should be free.
+	// Using an enum rather than a static const bool ensures that this trick works even
+	// with optimizations disabled on gcc.
+	enum CompileTimeCheck
 	{
-		IsUtlMap = true
+		IsUtlMap = 1
 	};
 };
 

--- a/public/tier1/utlmap.h
+++ b/public/tier1/utlmap.h
@@ -78,7 +78,7 @@ public:
 
 	
 	// Num elements
-	unsigned int Count() const								{ return m_Tree.Count(); }
+	IndexType_t  Count() const								{ return m_Tree.Count(); }
 
 	bool IsEmpty() const									{ return Count() == 0; }
 	
@@ -232,6 +232,23 @@ public:
 	IndexType_t  NextInorder( IndexType_t i ) const			{ return m_Tree.NextInorder( i ); }
 	IndexType_t  PrevInorder( IndexType_t i ) const			{ return m_Tree.PrevInorder( i ); }
 	IndexType_t  LastInorder() const						{ return m_Tree.LastInorder(); }		
+
+	// InvalidIndex once the neighbouring element has a different key
+	IndexType_t NextInorderSameKey( IndexType_t i ) const
+	{
+		IndexType_t iNext = NextInorder( i );
+		if ( !IsValidIndex( iNext ) || Key( iNext ) != Key( i ) )
+			return InvalidIndex();
+		return iNext;
+	}
+
+	IndexType_t PrevInorderSameKey( IndexType_t i ) const
+	{
+		IndexType_t iPrev = PrevInorder( i );
+		if ( !IsValidIndex( iPrev ) || Key( iPrev ) != Key( i ) )
+			return InvalidIndex();
+		return iPrev;
+	}
 	
 	// If you change the search key, this can be used to reinsert the 
 	// element into the map.

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -213,7 +213,7 @@ public:
 	I  Root() const;
 
 	// Num elements
-	unsigned int Count() const;
+	I  Count() const;
 
 	// Max "size" of the vector
 	// it's not generally safe to iterate from index 0 to MaxElement()-1
@@ -505,9 +505,9 @@ inline	I  CUtlRBTree<T, I, L, M>::Root() const
 //-----------------------------------------------------------------------------
 
 template < class T, class I, typename L, class M >
-inline	unsigned int CUtlRBTree<T, I, L, M>::Count() const          
-{ 
-	return (unsigned int)m_NumElements; 
+inline	I  CUtlRBTree<T, I, L, M>::Count() const
+{
+	return m_NumElements;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Also updated Count() return type

there is more to be added to map methods, but much of it requires a closer look at CUtlRBTree, which I will probably do as next separate PR unless requested otherwise

credit for split structure from wend4r/sourcesdk