### PR TITLE
BMS EmitGameSound crash fix

### DIFF
--- a/game/server/gameinterface.cpp
+++ b/game/server/gameinterface.cpp
@@ -2623,7 +2623,7 @@ bool CServerGameClients::ClientConnect( edict_t *pEdict, const char *pszName, co
 // Purpose: Called when a player is fully active (i.e. ready to receive messages)
 // Input  : *pEntity - the player
 //-----------------------------------------------------------------------------
-void CServerGameClients::ClientActive( edict_t *pEdict, bool bLoadGame )
+void CServerGameClients::ClientActive( edict_t *pEdict, bool bLoadGame, bool bUnknown)
 {
 	MDLCACHE_CRITICAL_SECTION();
 	

--- a/game/server/gameinterface.h
+++ b/game/server/gameinterface.h
@@ -29,7 +29,7 @@ class CServerGameClients : public IServerGameClients
 {
 public:
 	virtual bool			ClientConnect( edict_t *pEntity, char const* pszName, char const* pszAddress, char *reject, int maxrejectlen ) OVERRIDE;
-	virtual void			ClientActive( edict_t *pEntity, bool bLoadGame ) OVERRIDE;
+	virtual void			ClientActive( edict_t *pEntity, bool bLoadGame, bool bUnknown ) OVERRIDE;
 	virtual void			ClientDisconnect( edict_t *pEntity ) OVERRIDE;
 	virtual void			ClientPutInServer( edict_t *pEntity, const char *playername ) OVERRIDE;
 	virtual void			ClientCommand( edict_t *pEntity, const CCommand &args ) OVERRIDE;

--- a/public/SoundEmitterSystem/isoundemittersystembase.h
+++ b/public/SoundEmitterSystem/isoundemittersystembase.h
@@ -16,6 +16,7 @@
 #include "soundflags.h"
 #include "mathlib/compressed_vector.h"
 #include "appframework/IAppSystem.h"
+#include "stddef.h"
 
 
 #define SOUNDEMITTERSYSTEM_INTERFACE_VERSION	"VSoundEmitter002"
@@ -43,11 +44,16 @@ struct CSoundParameters
 		pitchhigh	= PITCH_NORM;
 
 		soundlevel	= SNDLVL_NORM; // 75dB
-		soundname[ 0 ] = 0;
 		play_to_owner_only = false;
-		count		= 0;
+		count = 0;
+		soundname[ 0 ] = 0;
 
 		delay_msec	= 0;
+
+		//for some info on these, read https://developer.valvesoftware.com/wiki/Music_track
+		m_fBPM = 0.0f;
+		m_fSignature = 0.0f;
+		m_fFadeTime = 0.0f;
 	}
 
 	int				channel;
@@ -60,7 +66,13 @@ struct CSoundParameters
 	int				count;
 	char 			soundname[ 128 ];
 	int				delay_msec;
+	
+	float			m_fBPM;              //0xA4
+	float			m_fSignature;        //0xA8
+	float			m_fFadeTime;         //0xAC
 };
+
+COMPILE_TIME_ASSERT(sizeof(CSoundParameters) == 0xB0); //this is the size we must have
 
 // A bit of a hack, but these are just utility function which are implemented in the SouneParametersInternal.cpp file which all users of this lib also compile
 const char *SoundLevelToString( soundlevel_t level );

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -693,7 +693,7 @@ public:
 
 	// Client is going active
 	// If bLoadGame is true, don't spawn the player because its state is already setup.
-	virtual void			ClientActive( edict_t *pEntity, bool bLoadGame ) = 0;
+	virtual void			ClientActive(edict_t* pEntity, bool bLoadGame, bool bUnknown) = 0;
 	
 	// Client is disconnecting from server
 	virtual void			ClientDisconnect( edict_t *pEntity ) = 0;


### PR DESCRIPTION
Fixes #78 
This was caused by improper object size. Turns out, Black Mesa has 3 extra float variables for CSoundParameters struct, the variables are used by [music_track](https://developer.valvesoftware.com/wiki/Music_track) entity and the music system.
Tested on Windows, sounds are played with no crashes.
This pull request also includes change that adds extra bool variable for CServerGameClients::ClientActive and the interface (see CServerPlugin::ClientActive on VTable Dumper). 