### PR TITLE
CS2: Add missing CUtlRBTree methods + CUtlOrderedMap methods

### DIFF
--- a/public/tier1/utlmap.h
+++ b/public/tier1/utlmap.h
@@ -62,9 +62,8 @@ public:
 	// at each increment.
 	// LessFunc_t is required, but may be set after the constructor using SetLessFunc() below
 	CUtlOrderedMapBase( int growSize, int initSize, const LessFunc_t &lessfunc )
-	 : m_Tree( growSize, initSize, CKeyLess( lessfunc ) )
-	{
-	}
+		: m_Tree( growSize, initSize, CKeyLess( lessfunc ) )
+	{}
 	
 	void EnsureCapacity( int num )							{ m_Tree.EnsureCapacity( num ); }
 
@@ -78,18 +77,18 @@ public:
 
 	
 	// Num elements
-	IndexType_t  Count() const								{ return m_Tree.Count(); }
+	IndexType_t Count() const								{ return m_Tree.Count(); }
 
 	bool IsEmpty() const									{ return Count() == 0; }
 	
 	// Max "size" of the vector
-	IndexType_t  MaxElement() const							{ return m_Tree.MaxElement(); }
+	IndexType_t MaxElement() const							{ return m_Tree.MaxElement(); }
 	
 	// Checks if a node is valid and in the map
-	bool  IsValidIndex( IndexType_t i ) const				{ return m_Tree.IsValidIndex( i ); }
+	bool IsValidIndex( IndexType_t i ) const				{ return m_Tree.IsValidIndex( i ); }
 	
 	// Checks if the map as a whole is valid
-	bool  IsValid() const									{ return m_Tree.IsValid(); }
+	bool IsValid() const									{ return m_Tree.IsValid(); }
 	
 	// Invalid index
 	static IndexType_t InvalidIndex()						{ return CTree::InvalidIndex(); }
@@ -101,7 +100,7 @@ public:
 	}
 	
 	// Insert method (inserts in order)
-	IndexType_t  Insert( const KeyType_t &key, const ElemType_t &insert )
+	IndexType_t Insert( const KeyType_t &key, const ElemType_t &insert )
 	{
 		Node_t node;
 		node.key = key;
@@ -109,7 +108,7 @@ public:
 		return m_Tree.Insert( node );
 	}
 	
-	IndexType_t  Insert( const KeyType_t &key )
+	IndexType_t Insert( const KeyType_t &key )
 	{
 		Node_t node;
 		node.key = key;
@@ -117,7 +116,7 @@ public:
 	}
 
 	// Inserts allowing duplicate keys
-	IndexType_t  InsertWithDupes( const KeyType_t &key, const ElemType_t &insert )
+	IndexType_t InsertWithDupes( const KeyType_t &key, const ElemType_t &insert )
 	{
 		Node_t node;
 		node.key = key;
@@ -125,7 +124,7 @@ public:
 		return m_Tree.Insert( node, k_eInsertAllowDupes );
 	}
 
-	IndexType_t  InsertWithDupes( const KeyType_t &key )
+	IndexType_t InsertWithDupes( const KeyType_t &key )
 	{
 		Node_t node;
 		node.key = key;
@@ -133,24 +132,15 @@ public:
 	}
 
 	// Insert with the given behavior, returns a pointer to the element
-	ElemType_t  *InsertGetPtr( const KeyType_t &key, ERBTreeInsertBehavior eInsertBehavior )
+	ElemType_t *InsertGetPtr( const KeyType_t &key, ERBTreeInsertBehavior eInsertBehavior )
 	{
 		Node_t node;
 		node.key = key;
 		return &Element( m_Tree.Insert( node, eInsertBehavior ) );
 	}
 
-	// Returns the existing index if the key is already present
-	IndexType_t InsertIfNotFound( const KeyType_t &key, const ElemType_t &insert )
-	{
-		Node_t node;
-		node.key = key;
-		node.elem = insert;
-		return m_Tree.InsertIfNotFound( node );
-	}
-
 	// pInserted reports whether an insert happened
-	IndexType_t FindOrInsert( const KeyType_t &key, const ElemType_t &insert, bool *pInserted = NULL )
+	IndexType_t FindOrInsert( const KeyType_t &key, const ElemType_t &insert = ElemType_t(), bool *pInserted = nullptr )
 	{
 		IndexType_t i = Find( key );
 		if ( i != InvalidIndex() )
@@ -165,23 +155,13 @@ public:
 		return Insert( key, insert );
 	}
 
-	IndexType_t FindOrInsertDefault( const KeyType_t &key, bool *pInserted = NULL )
-	{
-		return FindOrInsert( key, ElemType_t(), pInserted );
-	}
-
-	ElemType_t *FindOrInsertGetPtr( const KeyType_t &key, const ElemType_t &insert, bool *pInserted = NULL )
+	ElemType_t *FindOrInsertGetPtr( const KeyType_t &key, const ElemType_t &insert = ElemType_t(), bool *pInserted = nullptr )
 	{
 		return &Element( FindOrInsert( key, insert, pInserted ) );
 	}
 
-	ElemType_t *FindOrInsertDefaultGetPtr( const KeyType_t &key, bool *pInserted = NULL )
-	{
-		return &Element( FindOrInsertDefault( key, pInserted ) );
-	}
-
 	// Find method
-	IndexType_t  Find( const KeyType_t &key ) const
+	IndexType_t Find( const KeyType_t &key ) const
 	{
 		Node_t dummyNode;
 		dummyNode.key = key;
@@ -189,7 +169,7 @@ public:
 	}
 
 	// Finds the key, or the nearest lesser/greater element per eFindCondition
-	IndexType_t  Find( const KeyType_t &key, FindCondition_t eFindCondition ) const
+	IndexType_t Find( const KeyType_t &key, FindCondition_t eFindCondition ) const
 	{
 		Node_t dummyNode;
 		dummyNode.key = key;
@@ -197,7 +177,7 @@ public:
 	}
 
 	// Finds the first element (inorder) with this key when duplicates exist
-	IndexType_t  FindFirst( const KeyType_t &key ) const
+	IndexType_t FindFirst( const KeyType_t &key ) const
 	{
 		Node_t dummyNode;
 		dummyNode.key = key;
@@ -205,54 +185,59 @@ public:
 	}
 
 	// Finds the closest element to the key per the comparison criteria
-	IndexType_t  FindClosest( const KeyType_t &key, CompareOperands_t eFindCriteria ) const
+	IndexType_t FindClosest( const KeyType_t &key, CompareOperands_t eFindCriteria ) const
 	{
 		Node_t dummyNode;
 		dummyNode.key = key;
 		return m_Tree.FindClosest( dummyNode, eFindCriteria );
 	}
 
-	const ElemType_t &FindElement( const KeyType_t &key ) const
+	ElemType_t FindFirstElement( const KeyType_t &key, const ElemType_t &defaultValue ) const
 	{
-		return Element( Find( key ) );
+		IndexType_t i = FindFirst( key );
+		return i == InvalidIndex() ? defaultValue : Element( i );
+	}
+
+	ElemType_t FindClosestElement( const KeyType_t &key, const ElemType_t &defaultValue, CompareOperands_t eFindCriteria ) const
+	{
+		IndexType_t i = FindClosest( key, eFindCriteria );
+		return i == InvalidIndex() ? defaultValue : Element( i );
 	}
 
 	// By value, so a temporary defaultValue is safe
-	ElemType_t FindElement( const KeyType_t &key, const ElemType_t &defaultValue ) const
+	ElemType_t FindElement( const KeyType_t &key, const ElemType_t &defaultValue, FindCondition_t eFindCondition = FindCondition_t::EXACT_MATCH ) const
 	{
-		IndexType_t i = Find( key );
-		if ( i == InvalidIndex() )
-			return defaultValue;
-		return Element( i );
+		IndexType_t i = Find( key, eFindCondition );
+		return i == InvalidIndex() ? defaultValue : Element( i );
 	}
 
-	// NULL when the key isn't present
-	ElemType_t *FindGetPtr( const KeyType_t &key )
+	// nullptr when the key isn't present
+	ElemType_t *FindGetPtr( const KeyType_t &key, FindCondition_t eFindCondition = FindCondition_t::EXACT_MATCH )
 	{
-		IndexType_t i = Find( key );
-		return i == InvalidIndex() ? NULL : &Element( i );
+		IndexType_t i = Find( key, eFindCondition );
+		return i == InvalidIndex() ? nullptr : &Element( i );
 	}
 
-	const ElemType_t *FindGetPtr( const KeyType_t &key ) const
+	const ElemType_t *FindGetPtr( const KeyType_t &key, FindCondition_t eFindCondition = FindCondition_t::EXACT_MATCH ) const
 	{
-		IndexType_t i = Find( key );
-		return i == InvalidIndex() ? NULL : &Element( i );
+		IndexType_t i = Find( key, eFindCondition );
+		return i == InvalidIndex() ? nullptr : &Element( i );
 	}
 
 	bool HasElement( const KeyType_t &key ) const			{ return Find( key ) != InvalidIndex(); }
 	bool HasKey( const KeyType_t &key ) const				{ return Find( key ) != InvalidIndex(); }
 	
 	// Remove methods
-	void     RemoveAt( IndexType_t i )						{ m_Tree.RemoveAt( i ); }
-	bool     Remove( const KeyType_t &key )
+	void RemoveAt( IndexType_t i )							{ m_Tree.RemoveAt( i ); }
+	bool Remove( const KeyType_t &key )
 	{
 		Node_t dummyNode;
 		dummyNode.key = key;
 		return m_Tree.Remove( dummyNode );
 	}
 	
-	void     RemoveAll( )									{ m_Tree.RemoveAll(); }
-	void     Purge( )										{ m_Tree.Purge(); }
+	void RemoveAll( )										{ m_Tree.RemoveAll(); }
+	void Purge( )											{ m_Tree.Purge(); }
 
 	// Only valid when ElemType_t is a pointer
 	void PurgeAndDeleteElements()
@@ -276,10 +261,10 @@ public:
 	}
 			
 	// Iteration
-	IndexType_t  FirstInorder() const						{ return m_Tree.FirstInorder(); }
-	IndexType_t  NextInorder( IndexType_t i ) const			{ return m_Tree.NextInorder( i ); }
-	IndexType_t  PrevInorder( IndexType_t i ) const			{ return m_Tree.PrevInorder( i ); }
-	IndexType_t  LastInorder() const						{ return m_Tree.LastInorder(); }		
+	IndexType_t FirstInorder() const						{ return m_Tree.FirstInorder(); }
+	IndexType_t NextInorder( IndexType_t i ) const			{ return m_Tree.NextInorder( i ); }
+	IndexType_t PrevInorder( IndexType_t i ) const			{ return m_Tree.PrevInorder( i ); }
+	IndexType_t LastInorder() const							{ return m_Tree.LastInorder(); }
 
 	// InvalidIndex once the neighbouring element has a different key
 	IndexType_t NextInorderSameKey( IndexType_t i ) const
@@ -300,7 +285,7 @@ public:
 	
 	// If you change the search key, this can be used to reinsert the 
 	// element into the map.
-	void	Reinsert( const KeyType_t &key, IndexType_t i )
+	void Reinsert( const KeyType_t &key, IndexType_t i )
 	{
 		m_Tree[i].key = key;
 		m_Tree.Reinsert(i);
@@ -308,14 +293,10 @@ public:
 
 	IndexType_t InsertOrReplace( const KeyType_t &key, const ElemType_t &insert )
 	{
-		IndexType_t i = Find( key );
-		if ( i != InvalidIndex() )
-		{
-			Element( i ) = insert;
-			return i;
-		}
-		
-		return Insert( key, insert );
+		Node_t node;
+		node.key = key;
+		node.elem = insert;
+		return m_Tree.Insert( node, k_eInsertUpdateDupes );
 	}
 
 	void Swap( CUtlOrderedMapBase< K, T, LF, I > &that )
@@ -342,10 +323,9 @@ public:
 		}
 
 		Node_t( const Node_t &from )
-		  : key( from.key ),
+			: key( from.key ),
 			elem( from.elem )
-		{
-		}
+		{}
 
 		KeyType_t	key;
 		ElemType_t	elem;
@@ -374,7 +354,7 @@ public:
 	CTree *AccessTree()	{ return &m_Tree; }
 
 protected:
-	CTree 	   m_Tree;
+	CTree	m_Tree;
 };
 
 // Adds the default LessFunc and index type. Storage and logic live in the base.
@@ -385,14 +365,12 @@ public:
 	typedef CUtlOrderedMapBase< K, T, LF, I > BaseClass;
 
 	CUtlOrderedMap( int growSize, int initSize, const LF &lessfunc = LF() )
-	 : BaseClass( growSize, initSize, lessfunc )
-	{
-	}
+		: BaseClass( growSize, initSize, lessfunc )
+	{}
 
 	CUtlOrderedMap( const LF &lessfunc = LF() )
-	 : BaseClass( 0, 0, lessfunc )
-	{
-	}
+		: BaseClass( 0, 0, lessfunc )
+	{}
 };
 
 #endif // UTLMAP_H

--- a/public/tier1/utlmap.h
+++ b/public/tier1/utlmap.h
@@ -116,6 +116,30 @@ public:
 		return m_Tree.Insert( node );
 	}
 
+	// Inserts allowing duplicate keys
+	IndexType_t  InsertWithDupes( const KeyType_t &key, const ElemType_t &insert )
+	{
+		Node_t node;
+		node.key = key;
+		node.elem = insert;
+		return m_Tree.Insert( node, k_eInsertAllowDupes );
+	}
+
+	IndexType_t  InsertWithDupes( const KeyType_t &key )
+	{
+		Node_t node;
+		node.key = key;
+		return m_Tree.Insert( node, k_eInsertAllowDupes );
+	}
+
+	// Insert with the given behavior, returns a pointer to the element
+	ElemType_t  *InsertGetPtr( const KeyType_t &key, ERBTreeInsertBehavior eInsertBehavior )
+	{
+		Node_t node;
+		node.key = key;
+		return &Element( m_Tree.Insert( node, eInsertBehavior ) );
+	}
+
 	// Returns the existing index if the key is already present
 	IndexType_t InsertIfNotFound( const KeyType_t &key, const ElemType_t &insert )
 	{
@@ -162,6 +186,30 @@ public:
 		Node_t dummyNode;
 		dummyNode.key = key;
 		return m_Tree.Find( dummyNode );
+	}
+
+	// Finds the key, or the nearest lesser/greater element per eFindCondition
+	IndexType_t  Find( const KeyType_t &key, FindCondition_t eFindCondition ) const
+	{
+		Node_t dummyNode;
+		dummyNode.key = key;
+		return m_Tree.Find( dummyNode, eFindCondition );
+	}
+
+	// Finds the first element (inorder) with this key when duplicates exist
+	IndexType_t  FindFirst( const KeyType_t &key ) const
+	{
+		Node_t dummyNode;
+		dummyNode.key = key;
+		return m_Tree.FindFirst( dummyNode );
+	}
+
+	// Finds the closest element to the key per the comparison criteria
+	IndexType_t  FindClosest( const KeyType_t &key, CompareOperands_t eFindCriteria ) const
+	{
+		Node_t dummyNode;
+		dummyNode.key = key;
+		return m_Tree.FindClosest( dummyNode, eFindCriteria );
 	}
 
 	const ElemType_t &FindElement( const KeyType_t &key ) const

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -9,6 +9,7 @@
 #ifndef UTLRBTREE_H
 #define UTLRBTREE_H
 
+#include "dbg.h"
 #include "tier1/strtools.h"
 #include "tier1/utlleanvector.h"
 #include "tier1/utlfixedmemory.h"
@@ -281,13 +282,9 @@ public:
 	I  NewNode( bool bConstructElement );
 
 	// Insert method (inserts in order)
-	I  Insert( T const &insert );
-	void Insert( const T *pArray, int nItems );
+	I  Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior = k_eInsertAssertAboutDupes );
+	void Insert( const T *pArray, int nItems, ERBTreeInsertBehavior eInsertBehavior = k_eInsertAssertAboutDupes );
 	I  InsertIfNotFound( T const &insert );
-
-	// Insert with the given duplicate-key behavior
-	I  Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior );
-	void Insert( const T *pArray, int nItems, ERBTreeInsertBehavior eInsertBehavior );
 
 	// pInserted reports whether a new element was inserted
 	I  FindOrInsert( T const &insert, bool *pInserted = NULL );
@@ -1591,29 +1588,6 @@ void CUtlRBTree<T, I, L, M>::FindInsertionPosition( T const &insert, I &parent, 
 }
 
 template < class T, class I, typename L, class M > 
-I CUtlRBTree<T, I, L, M>::Insert( T const &insert )
-{
-	// use copy constructor to copy it in
-	I parent;
-	bool leftchild;
-	FindInsertionPosition( insert, parent, leftchild );
-	I newNode = InsertAt( parent, leftchild, false );
-	CopyConstruct( &Element( newNode ), insert );
-	return newNode;
-}
-
-
-template < class T, class I, typename L, class M > 
-void CUtlRBTree<T, I, L, M>::Insert( const T *pArray, int nItems )
-{
-	while ( nItems-- )
-	{
-		Insert( *pArray++ );
-	}
-}
-
-
-template < class T, class I, typename L, class M >
 I CUtlRBTree<T, I, L, M>::Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior )
 {
 	Assert( m_LessFunc );
@@ -1622,22 +1596,38 @@ I CUtlRBTree<T, I, L, M>::Insert( T const &insert, ERBTreeInsertBehavior eInsert
 	bool leftchild = false;
 
 	I current = m_Root;
-	while ( current != InvalidIndex() )
+	while(current != InvalidIndex())
 	{
 		parent = current;
-		if ( m_LessFunc( insert, Element( current ) ) )
+		if(m_LessFunc( insert, Element( current ) ))
 		{
 			leftchild = true;
 			current = LeftChild( current );
 		}
 		else
 		{
-			if ( eInsertBehavior == k_eInsertUpdateDupes && !m_LessFunc( Element( current ), insert ) )
+			// See if we've got a duplicate entry
+			if(!m_LessFunc( Element( current ), insert ))
 			{
-				// Key already present, overwrite the existing element
-				Element( current ) = insert;
-				return current;
+				switch(eInsertBehavior)
+				{
+					// Don't do anything on dupes if we allow them
+					case k_eInsertAllowDupes: break;
+
+					case k_eInsertUpdateDupes:
+					{
+						// Key already present, overwrite the existing element
+						Element( current ) = insert;
+						return current;
+					}
+
+					case k_eInsertAssertAboutDupes:
+					{
+						AssertMsg( false, "Allowing insert of dupe without explicit dupe insertion. Fix code callpoint to allow dupes." );
+					}
+				}
 			}
+
 			leftchild = false;
 			current = RightChild( current );
 		}

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -169,6 +169,22 @@ enum CompareOperands_t
 	k_ELessThanOrEqualTo = k_ELessThan | k_EEqual,
 };
 
+// For use with Find.
+enum FindCondition_t
+{
+	EXACT_MATCH = 0,
+	MATCH_OR_LESS = 1,
+	MATCH_OR_GREATER = 2,
+};
+
+// For use with Insert.
+enum ERBTreeInsertBehavior
+{
+	k_eInsertAssertAboutDupes = 0,
+	k_eInsertAllowDupes = 1,
+	k_eInsertUpdateDupes = 2,
+};
+
 //-----------------------------------------------------------------------------
 // A red-black binary search tree
 //-----------------------------------------------------------------------------
@@ -269,11 +285,18 @@ public:
 	void Insert( const T *pArray, int nItems );
 	I  InsertIfNotFound( T const &insert );
 
+	// Insert with the given duplicate-key behavior
+	I  Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior );
+	void Insert( const T *pArray, int nItems, ERBTreeInsertBehavior eInsertBehavior );
+
 	// pInserted reports whether a new element was inserted
 	I  FindOrInsert( T const &insert, bool *pInserted = NULL );
 
 	// Find method
 	I  Find( T const &search ) const;
+
+	// Finds the key, or the nearest lesser/greater element per eFindCondition
+	I  Find( T const &search, FindCondition_t eFindCondition ) const;
 
 	// Finds the first element (inorder) with this key when duplicates exist
 	I  FindFirst( T const &search ) const;
@@ -1590,6 +1613,51 @@ void CUtlRBTree<T, I, L, M>::Insert( const T *pArray, int nItems )
 }
 
 
+template < class T, class I, typename L, class M >
+I CUtlRBTree<T, I, L, M>::Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior )
+{
+	I parent = InvalidIndex();
+	bool leftchild = false;
+
+	I current = m_Root;
+	while ( current != InvalidIndex() )
+	{
+		parent = current;
+		if ( m_LessFunc( insert, Element( current ) ) )
+		{
+			leftchild = true;
+			current = LeftChild( current );
+		}
+		else
+		{
+			if ( eInsertBehavior == k_eInsertUpdateDupes && !m_LessFunc( Element( current ), insert ) )
+			{
+				// Key already present, overwrite the existing element
+				Element( current ) = insert;
+				return current;
+			}
+			leftchild = false;
+			current = RightChild( current );
+		}
+	}
+
+	// The non-update behaviors insert allowing dupes. AssertAboutDupes only asserts in debug.
+	I newNode = InsertAt( parent, leftchild, false );
+	CopyConstruct( &Element( newNode ), insert );
+	return newNode;
+}
+
+
+template < class T, class I, typename L, class M >
+void CUtlRBTree<T, I, L, M>::Insert( const T *pArray, int nItems, ERBTreeInsertBehavior eInsertBehavior )
+{
+	while ( nItems-- )
+	{
+		Insert( *pArray++, eInsertBehavior );
+	}
+}
+
+
 template < class T, class I, typename L, class M > 
 I CUtlRBTree<T, I, L, M>::InsertIfNotFound( T const &insert )
 {
@@ -1661,6 +1729,57 @@ I CUtlRBTree<T, I, L, M>::Find( T const &search ) const
 			break;
 	}
 	return current;
+}
+
+
+//-----------------------------------------------------------------------------
+// finds the node matching or nearest the key, per eFindCondition
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+I CUtlRBTree<T, I, L, M>::Find( T const &search, FindCondition_t eFindCondition ) const
+{
+	Assert( m_LessFunc );
+
+	I current = m_Root;
+	bool leftchild = false;
+	while ( current != InvalidIndex() )
+	{
+		if ( m_LessFunc( search, Element( current ) ) )
+		{
+			leftchild = true;
+			I child = LeftChild( current );
+			if ( child == InvalidIndex() )
+				break;
+			current = child;
+		}
+		else if ( m_LessFunc( Element( current ), search ) )
+		{
+			leftchild = false;
+			I child = RightChild( current );
+			if ( child == InvalidIndex() )
+				break;
+			current = child;
+		}
+		else
+		{
+			return current; // exact match
+		}
+	}
+
+	if ( current == InvalidIndex() )
+		return InvalidIndex();
+
+	// No exact match. current is the closest node, leftchild gives its side.
+	switch ( eFindCondition )
+	{
+	case MATCH_OR_LESS:
+		return leftchild ? PrevInorder( current ) : current;
+	case MATCH_OR_GREATER:
+		return leftchild ? current : NextInorder( current );
+	case EXACT_MATCH:
+	default:
+		return InvalidIndex();
+	}
 }
 
 

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -1641,7 +1641,7 @@ I CUtlRBTree<T, I, L, M>::Insert( T const &insert, ERBTreeInsertBehavior eInsert
 		}
 	}
 
-	// The non-update behaviors insert allowing dupes. AssertAboutDupes only asserts in debug.
+	// Both non-update behaviors insert the element, allowing duplicates.
 	I newNode = InsertAt( parent, leftchild, false );
 	CopyConstruct( &Element( newNode ), insert );
 	return newNode;

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -1616,6 +1616,8 @@ void CUtlRBTree<T, I, L, M>::Insert( const T *pArray, int nItems )
 template < class T, class I, typename L, class M >
 I CUtlRBTree<T, I, L, M>::Insert( T const &insert, ERBTreeInsertBehavior eInsertBehavior )
 {
+	Assert( m_LessFunc );
+
 	I parent = InvalidIndex();
 	bool leftchild = false;
 

--- a/public/tier1/utlrbtree.h
+++ b/public/tier1/utlrbtree.h
@@ -159,6 +159,16 @@ void SetDefLessFunc( RBTREE_T &RBTree )
 	RBTree.SetLessFunc( DefLessFunc( typename RBTREE_T::KeyType_t ) );
 }
 
+// For use with FindClosest.
+enum CompareOperands_t
+{
+	k_EEqual = 0x1,
+	k_EGreaterThan = 0x2,
+	k_ELessThan = 0x4,
+	k_EGreaterThanOrEqualTo = k_EGreaterThan | k_EEqual,
+	k_ELessThanOrEqualTo = k_ELessThan | k_EEqual,
+};
+
 //-----------------------------------------------------------------------------
 // A red-black binary search tree
 //-----------------------------------------------------------------------------
@@ -214,6 +224,7 @@ public:
 
 	// Num elements
 	I  Count() const;
+	bool  IsEmpty() const;
 
 	// Max "size" of the vector
 	// it's not generally safe to iterate from index 0 to MaxElement()-1
@@ -258,14 +269,29 @@ public:
 	void Insert( const T *pArray, int nItems );
 	I  InsertIfNotFound( T const &insert );
 
+	// pInserted reports whether a new element was inserted
+	I  FindOrInsert( T const &insert, bool *pInserted = NULL );
+
 	// Find method
 	I  Find( T const &search ) const;
+
+	// Finds the first element (inorder) with this key when duplicates exist
+	I  FindFirst( T const &search ) const;
+
+	// Finds the closest element to the key per the comparison criteria
+	I  FindClosest( T const &search, CompareOperands_t eFindCriteria ) const;
+
+	bool  HasElement( T const &search ) const;
 
 	// Remove methods
 	void     RemoveAt( I i );
 	bool     Remove( T const &remove );
 	void     RemoveAll( );
 	void	 Purge();
+
+	// Only valid when T is a pointer type
+	void RemoveAllAndDeleteElements();
+	void PurgeAndDeleteElements();
 
 	// Allocation, deletion
 	void  FreeNode( I i );
@@ -508,6 +534,12 @@ template < class T, class I, typename L, class M >
 inline	I  CUtlRBTree<T, I, L, M>::Count() const
 {
 	return m_NumElements;
+}
+
+template < class T, class I, typename L, class M >
+inline	bool CUtlRBTree<T, I, L, M>::IsEmpty() const
+{
+	return Count() == 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -1195,6 +1227,30 @@ void CUtlRBTree<T, I, L, M>::Purge()
 
 
 //-----------------------------------------------------------------------------
+// Removes all nodes and deletes the elements they point to
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+void CUtlRBTree<T, I, L, M>::RemoveAllAndDeleteElements()
+{
+	for ( I i = FirstInorder(); i != InvalidIndex(); i = NextInorder( i ) )
+		delete Element( i );
+	RemoveAll();
+}
+
+
+//-----------------------------------------------------------------------------
+// Purges the tree and deletes the elements the nodes point to
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+void CUtlRBTree<T, I, L, M>::PurgeAndDeleteElements()
+{
+	for ( I i = FirstInorder(); i != InvalidIndex(); i = NextInorder( i ) )
+		delete Element( i );
+	Purge();
+}
+
+
+//-----------------------------------------------------------------------------
 // iteration
 //-----------------------------------------------------------------------------
 
@@ -1567,6 +1623,26 @@ I CUtlRBTree<T, I, L, M>::InsertIfNotFound( T const &insert )
 
 
 //-----------------------------------------------------------------------------
+// finds an element, inserting it if it was not already present
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+I CUtlRBTree<T, I, L, M>::FindOrInsert( T const &insert, bool *pInserted )
+{
+	I i = Find( insert );
+	if ( i != InvalidIndex() )
+	{
+		if ( pInserted )
+			*pInserted = false;
+		return i;
+	}
+
+	if ( pInserted )
+		*pInserted = true;
+	return Insert( insert );
+}
+
+
+//-----------------------------------------------------------------------------
 // finds a node in the tree
 //-----------------------------------------------------------------------------
 template < class T, class I, typename L, class M > 
@@ -1585,6 +1661,92 @@ I CUtlRBTree<T, I, L, M>::Find( T const &search ) const
 			break;
 	}
 	return current;
+}
+
+
+//-----------------------------------------------------------------------------
+// finds the first node (inorder) with this key in the tree
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+I CUtlRBTree<T, I, L, M>::FindFirst( T const &search ) const
+{
+	Assert( m_LessFunc );
+
+	I current = m_Root;
+	I best = InvalidIndex();
+	while ( current != InvalidIndex() )
+	{
+		if ( m_LessFunc( search, Element( current ) ) )
+			current = LeftChild( current );
+		else if ( m_LessFunc( Element( current ), search ) )
+			current = RightChild( current );
+		else
+		{
+			best = current;
+			current = LeftChild( current );
+		}
+	}
+	return best;
+}
+
+
+//-----------------------------------------------------------------------------
+// finds the closest node to the key supplied
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+I CUtlRBTree<T, I, L, M>::FindClosest( T const &search, CompareOperands_t eFindCriteria ) const
+{
+	Assert( m_LessFunc );
+	Assert( ( eFindCriteria & ( k_EGreaterThan | k_ELessThan ) ) ^ ( k_EGreaterThan | k_ELessThan ) );
+
+	I current = m_Root;
+	I best = InvalidIndex();
+
+	while ( current != InvalidIndex() )
+	{
+		if ( m_LessFunc( search, Element( current ) ) )
+		{
+			// current node is > search
+			if ( eFindCriteria & k_EGreaterThan )
+				best = current;
+			current = LeftChild( current );
+		}
+		else if ( m_LessFunc( Element( current ), search ) )
+		{
+			// current node is < search
+			if ( eFindCriteria & k_ELessThan )
+				best = current;
+			current = RightChild( current );
+		}
+		else
+		{
+			// exact match
+			if ( eFindCriteria & k_EEqual )
+			{
+				best = current;
+				break;
+			}
+			else if ( eFindCriteria & k_EGreaterThan )
+			{
+				current = RightChild( current );
+			}
+			else if ( eFindCriteria & k_ELessThan )
+			{
+				current = LeftChild( current );
+			}
+		}
+	}
+	return best;
+}
+
+
+//-----------------------------------------------------------------------------
+// returns whether the key is present in the tree
+//-----------------------------------------------------------------------------
+template < class T, class I, typename L, class M >
+bool CUtlRBTree<T, I, L, M>::HasElement( T const &search ) const
+{
+	return Find( search ) != InvalidIndex();
 }
 
 


### PR DESCRIPTION
CUtlRBTree seems to also have public copy ctor + operator= but they seem undefined and private/protected on purpose?

FindFirst/FindClosest (and CompareOperands_t) are based on Wend4r's sourcesdk