### PR TITLE
Fix Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            cc: clang
-            cxx: clang++
+            cc: clang-22
+            cxx: clang++-22
             container_image: ghcr.io/alliedmodders/build-containers/debian11-clang22:latest
           - os: windows-2022
             cc: msvc
@@ -23,14 +23,14 @@ jobs:
       image: ${{ matrix.container_image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         name: Repository checkout
         with:
           fetch-depth: 0
           submodules: recursive
           path: repository
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         name: AMBuild checkout
         if: startsWith(runner.os, 'Windows')
         with:
@@ -41,6 +41,7 @@ jobs:
           path: ambuild
 
       - name: Setup AMBuild
+        if: startsWith(runner.os, 'Windows')
         shell: bash
         run: |
           python3 -m pip install ./ambuild


### PR DESCRIPTION
Taken from `l4d2` commits aa66aafeb0123712f629243c439ea0f546416f15 and 2a31cd007b2d7d2f964dc093eedcf7a812cf9dd6 to fix Linux CI runs being red for `tf2` PRs.