### PR TITLE
Expand Source 2 SDK engine coverage

### DIFF
--- a/game/shared/econ/econ_item_system.h
+++ b/game/shared/econ/econ_item_system.h
@@ -1,0 +1,23 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose:
+//
+//=============================================================================
+
+#ifndef ECON_ITEM_SYSTEM_H
+#define ECON_ITEM_SYSTEM_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "tier0/platform.h"
+
+class CEconItemSchema;
+
+abstract_class IEconItemSystem
+{
+public:
+	virtual CEconItemSchema *GetItemSchema() = 0;
+};
+
+#endif // ECON_ITEM_SYSTEM_H

--- a/game/shared/igamesystem.h
+++ b/game/shared/igamesystem.h
@@ -101,6 +101,7 @@ GS_EVENT_MSG( SpawnGroupPrecache )
 	CUtlString m_SpawnGroupName;
 	CUtlString m_EntityLumpName;
 	SpawnGroupHandle_t m_SpawnGroupHandle;
+	WorldGroupId_t m_hWorldGroupId;
 	int m_nEntityCount;
 	const EntitySpawnInfo_t *m_pEntitiesToSpawn;
 	ISpawnGroupPrerequisiteRegistry *m_pRegistry;

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -17,7 +17,7 @@
 #include "const.h"
 #include "in_buttons.h"
 
-#define TICK_INTERVAL			(1 / 64)
+#define TICK_INTERVAL			(1.0f / 64.0f)
 
 #define TIME_TO_TICKS( dt )		( (int)( 0.5f + (float)(dt) / TICK_INTERVAL ) )
 #define TICKS_TO_TIME( t )		( TICK_INTERVAL *( t ) )

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -535,49 +535,45 @@ struct ModelScale
 
 #include "soundflags.h"
 
-struct CSoundParameters;
-typedef short HSOUNDSCRIPTHANDLE;
-//-----------------------------------------------------------------------------
-// Purpose: Aggregates and sets default parameters for EmitSound function calls
-//-----------------------------------------------------------------------------
+typedef uint32 SoundEventGuid_t;
+
+struct SndOpEventGuid_t
+{
+	SoundEventGuid_t m_nGuid;
+	uint32 m_hStackHash;
+};
+
+#pragma pack(push, 1)
+struct StartSoundEventInfo
+{
+	SndOpEventGuid_t m_nSndOpEventGuid;
+	int32 m_nFlags;
+	uint64 m_nRecipients;
+};
+#pragma pack(pop)
+
 struct EmitSound_t
 {
 	EmitSound_t() :
-		m_nChannel( 0 ),
-		m_pSoundName( 0 ),
+		m_pSoundName( nullptr ),
+		m_vecSoundOrigin(),
 		m_flVolume( VOL_NORM ),
-		m_SoundLevel( SNDLVL_NONE ),
-		m_nFlags( 0 ),
-		m_nPitch( PITCH_NORM ),
-		m_pOrigin( 0 ),
 		m_flSoundTime( 0.0f ),
-		m_pflSoundDuration( 0 ),
-		m_bEmitCloseCaption( true ),
-		m_bWarnOnMissingCloseCaption( false ),
-		m_bWarnOnDirectWaveReference( false ),
-		m_nSpeakerEntity( -1 ),
-		m_UtlVecSoundOrigin(),
-		m_hSoundScriptHandle( -1 )
+		m_nForceGuid( 0 ),
+		m_nPitch( PITCH_NORM ),
+		m_nFlags( 0 )
 	{
 	}
 
-	EmitSound_t( const CSoundParameters &src );
-
-	int							m_nChannel;
-	char const					*m_pSoundName;
-	float						m_flVolume;
-	soundlevel_t				m_SoundLevel;
-	int							m_nFlags;
-	int							m_nPitch;
-	const Vector				*m_pOrigin;
-	float						m_flSoundTime; ///< NOT DURATION, but rather, some absolute time in the future until which this sound should be delayed
-	float						*m_pflSoundDuration;
-	bool						m_bEmitCloseCaption;
-	bool						m_bWarnOnMissingCloseCaption;
-	bool						m_bWarnOnDirectWaveReference;
-	int							m_nSpeakerEntity;
-	mutable CUtlVector< Vector >	m_UtlVecSoundOrigin;  ///< Actual sound origin(s) (can be multiple if sound routed through speaker entity(ies) )
-	mutable HSOUNDSCRIPTHANDLE		m_hSoundScriptHandle;
+	const char *m_pSoundName;
+	Vector m_vecSoundOrigin;
+	float m_flVolume;
+	float m_flSoundTime;
+	uint8 m_Pad1C[4] = {};
+	uint32 m_nForceGuid;
+	uint8 m_Pad24[4] = {};
+	int16 m_nPitch;
+	uint8 m_nFlags;
 };
 
 #define MAX_ACTORS_IN_SCENE 16

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -268,6 +268,27 @@ enum DamageTypes_t
 	DMG_HEADSHOT		= (1 << 19)
 };
 
+enum TakeDamageFlags_t : uint64
+{
+	DFLAG_NONE = 0,
+	DFLAG_SUPPRESS_HEALTH_CHANGES = uint64(1) << 0,
+	DFLAG_SUPPRESS_PHYSICS_FORCE = uint64(1) << 1,
+	DFLAG_SUPPRESS_EFFECTS = uint64(1) << 2,
+	DFLAG_PREVENT_DEATH = uint64(1) << 3,
+	DFLAG_FORCE_DEATH = uint64(1) << 4,
+	DFLAG_ALWAYS_GIB = uint64(1) << 5,
+	DFLAG_NEVER_GIB = uint64(1) << 6,
+	DFLAG_REMOVE_NO_RAGDOLL = uint64(1) << 7,
+	DFLAG_SUPPRESS_DAMAGE_MODIFICATION = uint64(1) << 8,
+	DFLAG_ALWAYS_FIRE_DAMAGE_EVENTS = uint64(1) << 9,
+	DFLAG_RADIUS_DMG = uint64(1) << 10,
+	DFLAG_FORCEREDUCEARMOR_DMG = uint64(1) << 11,
+	DFLAG_SUPPRESS_INTERRUPT_FLINCH = uint64(1) << 12,
+	DFLAG_IGNORE_DESTRUCTIBLE_PARTS = uint64(1) << 13,
+	DFLAG_IGNORE_ARMOR = uint64(1) << 14,
+	DFLAG_SUPPRESS_UTILREMOVE = uint64(1) << 15,
+};
+
 // settings for m_takedamage
 #define	DAMAGE_NO				0
 #define DAMAGE_EVENTS_ONLY		1		// Call damage functions, but don't modify health

--- a/public/checktransmitinfo.h
+++ b/public/checktransmitinfo.h
@@ -6,19 +6,33 @@
 
 #include "bitvec.h"
 #include "const.h"
+#include "entity2/entityidentity.h"
+#include "playerslot.h"
+#include "tier1/utlvector.h"
 
 // Entities can span this many clusters before we revert to a slower area checking algorithm
 #define	MAX_FAST_ENT_CLUSTERS	4
 #define	MAX_ENT_CLUSTERS	64
 #define MAX_WORLD_AREAS		8
 
+struct vis_info_t
+{
+	uint32 m_uVisBitsBufSize;
+	SpawnGroupHandle_t m_SpawnGroupHandle;
+	CBitVec<4096> m_VisBits;
+};
+
 class CCheckTransmitInfo
 {
 public:
-	CBitVec<MAX_EDICTS>	*m_pTransmitEntity;	// entity n is already marked for transmission
-	CBitVec<MAX_EDICTS>	*m_pTransmitAlways; // entity n is always send even if not in PVS (HLTV and Replay only)
-
-	// AMNOTE: This is incomplete and may require further reversing in the future.
+	CBitVec<MAX_EDICTS> *m_pTransmitEntity;
+	CBitVec<MAX_EDICTS> *m_pTransmitNonPlayers;
+	CBitVec<MAX_EDICTS> *m_pTransmitOutOfPVS;
+	CBitVec<MAX_EDICTS> *m_pTransmitAlways;
+	CUtlVector<CPlayerSlot> m_vecTargetSlots;
+	vis_info_t m_VisInfo;
+	CPlayerSlot m_nPlayerSlot;
+	bool m_bFullUpdate;
 };
 
 //-----------------------------------------------------------------------------

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -527,10 +527,6 @@ public:
 
 	virtual int			GetNetworkVersion( void ) = 0;
 
-	// Get the simulation interval (must be compiled with identical values into both client and game .dll for MOD!!!)
-	// Right now this is only requested at server startup time so it can't be changed on the fly, etc.
-	virtual float			GetTickInterval( void ) const = 0;
-
 	// Get server maxplayers and lower bound for same
 	virtual void			GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers, bool &bIsMultiplayer ) const = 0;
 

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -305,7 +305,7 @@ public:
 	// Returns the XUID of the specified player. It'll be NULL if the player hasn't connected yet.
 	virtual uint64 GetClientXUID( CPlayerSlot nSlot ) = 0;
 
-	virtual void				*GetPVSForSpawnGroup( SpawnGroupHandle_t spawnGroup ) = 0;
+	virtual IPVS				*GetPVSForSpawnGroup( SpawnGroupHandle_t spawnGroup ) = 0;
 	virtual SpawnGroupHandle_t	FindSpawnGroupByName( const char *szName ) = 0;
 
 	// Returns the SteamID of the game server

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -73,6 +73,7 @@ class CNavData;
 struct EconItemInfo_t;
 struct EconControlPointInfo_t;
 class CEntityHandle;
+class IEconItemSystem;
 struct RenderDeviceInfo_t;
 
 enum RenderMultisampleType_t : uint8
@@ -470,7 +471,7 @@ public:
 	virtual void			GetCharacterList( CUtlVector<CUtlString> &characterNames ) = 0;
 	virtual void			GetDefaultChoreoDirForModel( const char *pModelName, CBufferString &defaultVCDDir ) = 0;
 
-	virtual void			*GetEconItemSystem( void ) = 0;
+	virtual IEconItemSystem	*GetEconItemSystem( void ) = 0;
 
 	virtual void			ServerConVarChanged( const char *pVarName, const char *pValue ) = 0;
 

--- a/public/engine/IPVS.h
+++ b/public/engine/IPVS.h
@@ -1,0 +1,40 @@
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//
+// Purpose:
+//
+//===========================================================================//
+
+#ifndef IPVS_H
+#define IPVS_H
+
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "mathlib/vector.h"
+#include "tier0/basetypes.h"
+
+class CFrustum;
+class OBB_t;
+struct AABB_t;
+
+enum PVSCluster_t
+{
+	PVS_CLUSTER_VISIBLE_EVERYWHERE = 0,
+};
+
+abstract_class IPVS
+{
+public:
+	virtual int GetClustersForOrigin( uint32 *pList, int nListMax, const Vector &vOrigin ) = 0;
+	virtual int GetClustersForBounds( uint32 *pList, int nListMax, const Vector &vMins, const Vector &vMaxs, bool bIsStatic ) = 0;
+	virtual int GetClustersForOrientedBounds( uint32 *pList, int nListMax, const OBB_t &bounds, bool bIsStatic ) = 0;
+	virtual int GetClustersForFrustum( uint32 *pList, int nListMax, const CFrustum *pFrustum, bool bIsStatic ) = 0;
+	virtual int GetVisibleEverywhereClusterList( uint32 *pList, int nListMax ) = 0;
+	virtual int FilterClustersInRadius( uint32 *pList, int nList, const Vector &vOrigin, float flRadius ) = 0;
+	virtual int GetClusterCount() = 0;
+	virtual int GetAllClusterBounds( AABB_t *pBBoxList, int nMaxBBox ) = 0;
+	virtual int GetClusterForPosition( const Vector &vPosition ) const = 0;
+};
+
+#endif // IPVS_H

--- a/public/entity2/entityclass.h
+++ b/public/entity2/entityclass.h
@@ -44,10 +44,18 @@ typedef enum
 	USE_TOGGLE = 3
 } USE_TYPE;
 
+struct EntityUseInput_t
+{
+	CEntityInstance *m_pActivator;
+	CEntityInstance *m_pCaller;
+	USE_TYPE m_nType;
+	float m_flValue;
+};
+
 // AMNOTE: In action these are member function ptrs instead of raw pointers
 typedef void (*BASEPTR)(CEntityInstance *ent);
 typedef void (*ENTITYFUNCPTR)(CEntityInstance *pOther);
-typedef void (*USEPTR)(CEntityInstance *pActivator, CEntityInstance *pCaller, USE_TYPE useType, float value);
+typedef void (*USEPTR)(const EntityUseInput_t *input);
 
 struct EntClassComponentOverride_t
 {

--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -17,6 +17,7 @@ class CEntityKeyValues;
 class CFieldPath;
 class ISave;
 class IRestore;
+struct ScriptClassDesc_t;
 struct CEntityPrecacheContext;
 struct ChangeAccessorFieldPathIndexInfo_t;
 struct datamap_t;
@@ -84,7 +85,7 @@ public:
 	virtual void unk001() = 0;
 	virtual void unk002() = 0;
 
-	virtual void* GetScriptDesc() = 0;
+	virtual ScriptClassDesc_t* GetScriptDesc() = 0;
 	
 	virtual ~CEntityInstance() = 0;
 	

--- a/public/entity2/entityinstance.h
+++ b/public/entity2/entityinstance.h
@@ -11,6 +11,7 @@
 #include "schemasystem/schematypes.h"
 #include <initializer_list>
 
+class CEntityInstance;
 class CNetworkSerializerClassInfo;
 class CEntityKeyValues;
 class CFieldPath;
@@ -63,6 +64,16 @@ struct NetworkStateChangedData
 	ChangeAccessorFieldPathIndex_t m_nPathIndex;
 
 	int16 m_unk101; // default 0, if m_LocalOffsets has multiple values, it is set to 1
+};
+
+struct CNetworkVarChainer
+{
+	void NetworkStateChanged( uint32 nLocalOffset, int32 nArrayIndex = -1 ) const;
+
+	CEntityInstance *m_pEntity;
+	uint8 m_Reserved0[24];
+	ChangeAccessorFieldPathIndex_t m_PathIndex;
+	uint8 m_Reserved1[4];
 };
 
 class CEntityInstance
@@ -189,6 +200,14 @@ inline const CEntityHandle &CEntityHandle::Set( const CEntityInstance *pEntity )
 	}
 
 	return *this;
+}
+
+inline void CNetworkVarChainer::NetworkStateChanged( uint32 nLocalOffset, int32 nArrayIndex ) const
+{
+	if ( m_pEntity )
+	{
+		m_pEntity->NetworkStateChanged( NetworkStateChangedData( nLocalOffset, nArrayIndex, m_PathIndex ) );
+	}
 }
 
 #endif // ENTITYINSTANCE_H

--- a/public/entity2/entitykeyvalues.h
+++ b/public/entity2/entitykeyvalues.h
@@ -8,6 +8,7 @@
 #include "tier1/keyvalues3.h"
 #include "tier1/utlleanvector.h"
 #include "entity2/entitysystem.h"
+#include "schemasystem/schematypes.h"
 
 #include "tier0/memdbgon.h"
 
@@ -35,6 +36,30 @@ struct EntityIOConnectionDescFat_t
 	int32 m_nTimesToFire;
 
 	KeyValues3 m_KV3Value;
+};
+
+struct EntityIOConnection_t;
+class CKV3TransferSaveContext;
+class CKV3TransferLoadContext;
+
+struct EntityIOOutputDesc_t
+{
+	const char *m_pName;
+	uint32 m_nFlags;
+	uint32 m_nOutputOffset;
+};
+
+class CEntityIOOutput
+{
+public:
+	virtual SchemaMetaInfoHandle_t<CSchemaClassInfo> Schema_DynamicBinding() = 0;
+	// Named after the exported CUtlStringAndTokenWithStorage::KV3Transfer* pair that takes the same contexts
+	virtual void KV3TransferSave( CKV3TransferSaveContext *pContext ) const = 0;
+	virtual void KV3TransferLoad( CKV3TransferLoadContext *pContext ) = 0;
+
+public:
+	EntityIOConnection_t *m_pConnections;
+	EntityIOOutputDesc_t *m_pDesc;
 };
 
 abstract_class IEntityKeyComplex

--- a/public/entity2/entitykeyvalues.h
+++ b/public/entity2/entitykeyvalues.h
@@ -136,6 +136,7 @@ public:
 	void RemoveConnectionDesc( int nDesc );
 
 	EntityIOConnectionDescFat_t* GetConnectionDesc( int nDesc ) { return &m_connectionDescs[nDesc]; }
+	const EntityIOConnectionDescFat_t* GetConnectionDesc( int nDesc ) const { return &m_connectionDescs[nDesc]; }
 	int GetNumConnectionDescs() const { return m_connectionDescs.Count(); }
 
 	void CopyFrom( const CEntityKeyValues* pSrc, bool bRemoveAllKeys = false, bool bSkipEHandles = false );

--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -416,17 +416,17 @@ public:
 	// IBaseFileSystem
 	//--------------------------------------------------------
 	virtual int				Read(void* pOutput, int size, FileHandle_t file) = 0;
-	virtual int				Write(void const* pInput, int size, FileHandle_t file) = 0;
+	virtual int				Write(void const* pInput, uint64 size, FileHandle_t file) = 0;
 
 	// if pathID is NULL, all paths will be searched for the file
 	virtual FileHandle_t	Open(const char *pFileName, const char *pOptions, const char *pathID = 0) = 0;
 	virtual void			Close(FileHandle_t file) = 0;
 
 
-	virtual void			Seek(FileHandle_t file, int pos, FileSystemSeek_t seekType) = 0;
-	virtual unsigned int	Tell(FileHandle_t file) = 0;
-	virtual unsigned int	Size(FileHandle_t file) = 0;
-	virtual unsigned int	Size(const char *pFileName, const char *pPathID = 0) = 0;
+	virtual void			Seek(FileHandle_t file, int64 pos, FileSystemSeek_t seekType) = 0;
+	virtual int64			Tell(FileHandle_t file) = 0;
+	virtual int64			Size(FileHandle_t file) = 0;
+	virtual int64			Size(const char *pFileName, const char *pPathID = 0) = 0;
 
 	virtual void			Flush(FileHandle_t file) = 0;
 	virtual bool			Precache(const char *pFileName, const char *pPathID = 0) = 0;

--- a/public/igameevents.h
+++ b/public/igameevents.h
@@ -158,8 +158,8 @@ public:
 	// removes all and anything
 	virtual void  Reset() = 0;	
 
-	// adds a listener for a particular event
-	virtual bool AddListener( IGameEventListener2 *listener, const char *name, bool bServerSide ) = 0;
+	// adds a listener for a particular event; returns its index, or -1
+	virtual int AddListener( IGameEventListener2 *listener, const char *name, bool bServerSide ) = 0;
 
 	// returns true if this listener is listens to given event
 	virtual bool FindListener( IGameEventListener2 *listener, const char *name ) = 0;

--- a/public/iserver.h
+++ b/public/iserver.h
@@ -183,9 +183,8 @@ public:
 	// Returns hostname of this server instance
 	virtual const char *GetHostName() = 0;
 
-	// AMNOTE: arg names are speculative and might be incorrect!
 	// Sums up across all the connected players.
-	virtual void	GetNetStats( float &inflow, float &outflow ) = 0;
+	virtual void	GetNetStats( float &avgIn, float &avgOut ) = 0;
 
 	virtual void	FillKV3ServerInfo( KeyValues3 *out ) = 0;
 

--- a/public/networksystem/inetworkserializer.h
+++ b/public/networksystem/inetworkserializer.h
@@ -304,6 +304,12 @@ public:
 		int8_t m_nFlags;
 	};
 
+	CNetworkSerializerClassInfo *FindClass( const char *class_name ) const
+	{
+		int index = m_ClassInfos.Find( class_name );
+		return index == m_ClassInfos.InvalidIndex() ? nullptr : m_ClassInfos[index];
+	}
+
 	CUtlString m_ModuleName;
 	CUtlDict<CNetworkSerializerClassInfo *> m_ClassInfos;
 	CUtlDict<CNetworkSerializerCodeGenDatabase::EnumInfo_t> m_EnumInfos;

--- a/public/soundsystem/isoundopsystem.h
+++ b/public/soundsystem/isoundopsystem.h
@@ -1,0 +1,84 @@
+//========= Copyright © 1996-2005, Valve Corporation, All rights reserved. ============//
+//
+// Purpose:
+//
+//=============================================================================//
+
+#ifndef ISOUNDOPSYSTEM_H
+#define ISOUNDOPSYSTEM_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "tier0/platform.h"
+
+class CUtlString;
+
+abstract_class CSoundEventManager
+{
+public:
+	virtual uint32 GetSoundEventHash( const char *pSoundEvent ) = 0;
+	virtual bool IsValidSoundEventHash( uint32 nSoundEvent ) = 0;
+	virtual const char *GetSoundEventName( uint32 nSoundEvent ) = 0;
+	virtual bool HasSoundEvent( const char *pSoundEvent ) = 0;
+
+private:
+	virtual void *GetSoundEventByHash( uint32 nSoundEvent, bool bWarn ) = 0;
+	virtual void *GetSoundEventByName( const char *pSoundEvent ) = 0;
+	virtual void unk001() = 0;
+	virtual void unk002() = 0;
+	virtual void unk003() = 0;
+	virtual void unk004() = 0;
+	virtual void unk005() = 0;
+	virtual void unk006() = 0;
+	virtual void unk007() = 0;
+	virtual void unk008() = 0;
+	virtual void unk009() = 0;
+	virtual void unk010() = 0;
+
+public:
+	virtual uint32 GetSoundEventStackHash( uint32 nSoundEvent ) = 0;
+	virtual uint32 GetSoundEventStackHash( const char *pSoundEvent ) = 0;
+	virtual void GetSoundEventStackName( uint32 nSoundEvent, CUtlString &sStackName ) = 0;
+
+private:
+	virtual void unk101() = 0;
+	virtual void unk102() = 0;
+
+public:
+	virtual uint32 GetSoundEventDefinitionBaseHash( uint32 nSoundEvent, int nIndex ) = 0;
+	virtual uint32 GetSoundEventDefinitionBaseHash( const char *pSoundEvent, int nIndex ) = 0;
+	virtual void GetSoundEventDefinitionBaseName( uint32 nSoundEvent, CUtlString &sBaseName, int nIndex ) = 0;
+	virtual void GetSoundEventDefinitionBaseField( uint32 nSoundEvent, CUtlString &sBaseField, int nIndex ) = 0;
+	virtual int GetSoundEventDefinitionBaseCount( uint32 nSoundEvent ) = 0;
+	virtual int GetSoundEventDefinitionBaseCount( const char *pSoundEvent ) = 0;
+
+private:
+	virtual void unk201() = 0;
+
+public:
+	virtual void *GetSoundEventUpdateGroups( uint32 nSoundEvent ) = 0;
+	virtual void *GetSoundEventGroups( const char *pSoundEvent ) = 0;
+
+private:
+	virtual void unk301() = 0;
+	virtual void unk302() = 0;
+	virtual void unk303() = 0;
+	virtual void unk304() = 0;
+
+public:
+	virtual void PreloadSoundEvent( uint32 nSoundEvent, int16 nPriority ) = 0;
+	virtual void PreloadSoundEvent( const char *pSoundEvent, int16 nPriority ) = 0;
+};
+
+class ISoundOpSystem
+{
+public:
+	CSoundEventManager *GetSoundEventManager()
+	{
+		uint8 *pAddress = reinterpret_cast<uint8 *>( this );
+		return reinterpret_cast<CSoundEventManager *>( pAddress + sizeof( void * ) );
+	}
+};
+
+#endif // ISOUNDOPSYSTEM_H

--- a/public/soundsystem/isoundsystem.h
+++ b/public/soundsystem/isoundsystem.h
@@ -1,0 +1,59 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose:
+//
+//===========================================================================//
+
+#ifndef ISOUNDSYSTEM_H
+#define ISOUNDSYSTEM_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "appframework/IAppSystem.h"
+#include "soundflags.h"
+
+class CAudioState;
+
+#define SOUNDSYSTEM_INTERFACE_VERSION "SoundSystem001"
+
+abstract_class ISoundSystem : public IAppSystem
+{
+private:
+	virtual void unk001() = 0;
+	virtual void unk002() = 0;
+	virtual void unk003() = 0;
+	virtual void unk004() = 0;
+	virtual void unk005() = 0;
+	virtual void unk006() = 0;
+	virtual void unk007() = 0; // Behaves like IEngineSound::CreateOutputStream
+	virtual void unk008() = 0;
+	virtual void unk009() = 0; // Behaves like IEngineSound::DestroyOutputStream
+	virtual void unk010() = 0;
+	virtual void unk011() = 0;
+
+public:
+	virtual void Update( const CAudioState *pAudioState, bool bUnk ) = 0;
+
+private:
+	virtual void unk101() = 0; // Behaves like IEngineSound::StopAllSounds
+	virtual void unk102() = 0;
+	virtual void unk103() = 0;
+	virtual void unk104() = 0; // Behaves like IEngineSound::StopSoundByGuid
+	virtual void unk105() = 0;
+	virtual void unk106() = 0;
+	virtual void unk107() = 0;
+	virtual void unk108() = 0; // Behaves like IEngineSound::IsSoundStillPlaying
+	virtual void unk109() = 0; // Behaves like IEngineSound::SetVolumeByGuid
+	virtual void unk110() = 0;
+	virtual void unk111() = 0;
+	virtual void unk112() = 0;
+	virtual void unk113() = 0;
+	virtual void unk114() = 0;
+	virtual void unk115() = 0;
+
+public:
+	virtual float GetDistGainFromSoundLevel( soundlevel_t soundLevel, float flDistance, float flDbLoss = 0.0f ) = 0;
+};
+
+#endif // ISOUNDSYSTEM_H

--- a/public/tier0/vprof.h
+++ b/public/tier0/vprof.h
@@ -12,6 +12,7 @@
 #include "tier0/fasttimer.h"
 #include "tier0/l2cache.h"
 #include "tier0/threadtools.h"
+#include "tier1/utlvector.h"
 
 // VProf is enabled by default in all configurations -except- X360 Retail.
 #if !( defined( _X360 ) && defined( _CERT ) )
@@ -583,6 +584,45 @@ protected:
 //-------------------------------------
 
 PLATFORM_INTERFACE CVProfile g_VProfCurrentProfile;
+
+// Layout used by VProfLite_GetHistoricalData in libtier0.
+struct VProfLiteReportItem_t
+{
+	int m_nBudgetGroupID;
+	const char *m_pszName;
+	int m_nActiveSamples;
+	int m_nActiveSamples1SecondMax;
+	float m_flActiveAverage;
+	float m_flActiveP25;
+	float m_flActiveP50;
+	float m_flActiveP95;
+	float m_flActiveP99;
+	float m_flAllAverage;
+	float m_flAllP25;
+	float m_flAllP50;
+	float m_flAllP95;
+	float m_flAllP99;
+	float m_flActive1SecondMaxAverage;
+	float m_flActive1SecondMaxP25;
+	float m_flActive1SecondMaxP50;
+	float m_flActive1SecondMaxP95;
+	float m_flActive1SecondMaxP99;
+	float m_flAll1SecondMaxAverage;
+	float m_flAll1SecondMaxP25;
+	float m_flAll1SecondMaxP50;
+	float m_flAll1SecondMaxP95;
+	float m_flAll1SecondMaxP99;
+	float m_flMax;
+};
+
+struct VProfLiteReport_t
+{
+	int m_nDiscardedFrames;
+	CUtlVector<VProfLiteReportItem_t> m_Items;
+};
+
+PLATFORM_INTERFACE void VProfLite_GetHistoricalData( VProfLiteReport_t *pReport );
+PLATFORM_INTERFACE bool VProfLite_GetEnabled();
 
 
 //-----------------------------------------------------------------------------

--- a/public/tier1/KeyValues.h
+++ b/public/tier1/KeyValues.h
@@ -361,7 +361,7 @@ public:
 	void RecursiveSaveToFile( CUtlBuffer &buf, int indentLevel, bool bSortKeys = false, bool bAllowEmptyString = false ) const;
 	void RecursiveSaveToLocalizationFile( IFileSystem *filesystem, void *buf, int indentLevel, bool bAllowEmptyString = false );
 
-	bool WriteAsBinary( CUtlBuffer &buffer );
+	bool WriteAsBinary( CUtlBuffer &buffer ) const;
 	bool WriteAsBinaryFiltered( CUtlBuffer &buffer );
 	bool ReadAsBinary( CUtlBuffer &buffer );
 	bool ReadAsBinaryFiltered( CUtlBuffer &buffer );

--- a/public/vscript/ivscript.h
+++ b/public/vscript/ivscript.h
@@ -99,6 +99,7 @@
 #include "datamap.h"
 #include "appframework/IAppSystem.h"
 #include "tier1/functors.h"
+#include <cstring>
 #include "tier0/memdbgon.h"
 
 #if defined( _WIN32 )
@@ -237,12 +238,15 @@ enum ScriptFuncBindingFlags_t
 
 typedef bool (*ScriptBindingFunc_t)( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn );
 
+struct ScriptClassDesc_t;
+
 struct ScriptFunctionBinding_t
 {
 	ScriptFuncDescriptor_t	m_desc;
+	ScriptClassDesc_t *		m_pClassDesc;
 	ScriptBindingFunc_t		m_pfnBinding;
 	void *					m_pFunction;
-	unsigned				m_flags;
+	ScriptFuncBindingFlags_t m_flags;
 };
 
 //---------------------------------------------------------
@@ -269,6 +273,21 @@ struct ScriptClassDesc_t
 	void *(*m_pfnConstruct)();
 	void (*m_pfnDestruct)( void *);
 	IScriptInstanceHelper *				pHelper; // optional helper
+
+	const ScriptFunctionBinding_t *FindFunctionBinding( const char *functionName ) const
+	{
+		for ( const ScriptClassDesc_t *desc = this; desc; desc = desc->m_pBaseDesc )
+		{
+			for ( int index = 0; index < desc->m_FunctionBindings.Count(); index++ )
+			{
+				const ScriptFunctionBinding_t &binding = desc->m_FunctionBindings[index];
+				const char *name = binding.m_desc.m_pszScriptName;
+				if ( name && std::strcmp( name, functionName ) == 0 )
+					return &binding;
+			}
+		}
+		return nullptr;
+	}
 };
 
 //-----------------------------------------------------------------------------
@@ -279,11 +298,11 @@ struct ScriptClassDesc_t
 
 // Lower level macro primitives
 #define ScriptInitFunctionBinding( pScriptFunction, func )									ScriptInitFunctionBindingNamed( pScriptFunction, func, #func )
-#define ScriptInitFunctionBindingNamed( pScriptFunction, func, scriptName )					do { ScriptInitFuncDescriptorNamed( (&(pScriptFunction)->m_desc), func, scriptName ); (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( &func ); (pScriptFunction)->m_pFunction = (void *)&func; } while (0)
+#define ScriptInitFunctionBindingNamed( pScriptFunction, func, scriptName )					do { ScriptInitFuncDescriptorNamed( (&(pScriptFunction)->m_desc), func, scriptName ); (pScriptFunction)->m_pClassDesc = NULL; (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( &func ); (pScriptFunction)->m_pFunction = (void *)&func; (pScriptFunction)->m_flags = ScriptFuncBindingFlags_t(0); } while (0)
 
 #define ScriptInitMemberFunctionBinding( pScriptFunction, class, func )						ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, #func )
 #define ScriptInitMemberFunctionBindingNamed( pScriptFunction, class, func, scriptName )	ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, scriptName )
-#define ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, scriptName ) 		do { ScriptInitMemberFuncDescriptor_( (&(pScriptFunction)->m_desc), class, func, scriptName ); (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( ((class *)0), &class::func ); 	(pScriptFunction)->m_pFunction = ScriptConvertFuncPtrToVoid( &class::func ); (pScriptFunction)->m_flags = SF_MEMBER_FUNC;  } while (0)
+#define ScriptInitMemberFunctionBinding_( pScriptFunction, class, func, scriptName ) 		do { ScriptInitMemberFuncDescriptor_( (&(pScriptFunction)->m_desc), class, func, scriptName ); (pScriptFunction)->m_pClassDesc = NULL; (pScriptFunction)->m_pfnBinding = ScriptCreateBinding( ((class *)0), &class::func ); 	(pScriptFunction)->m_pFunction = ScriptConvertFuncPtrToVoid( &class::func ); (pScriptFunction)->m_flags = SF_MEMBER_FUNC;  } while (0)
 
 #define ScriptInitClassDesc( pClassDesc, class, pBaseClassDesc )							ScriptInitClassDescNamed( pClassDesc, class, pBaseClassDesc, #class )
 #define ScriptInitClassDescNamed( pClassDesc, class, pBaseClassDesc, scriptName )			ScriptInitClassDescNamed_( pClassDesc, class, pBaseClassDesc, scriptName )
@@ -292,7 +311,7 @@ struct ScriptClassDesc_t
 #define ScriptInitClassDescNamed_( pClassDesc, class, pBaseClassDesc, scriptName )			do { (pClassDesc)->m_pszScriptName = scriptName; (pClassDesc)->m_pszClassname = #class; (pClassDesc)->m_pBaseDesc = pBaseClassDesc; } while ( 0 )
 
 #define ScriptAddFunctionToClassDesc( pClassDesc, class, func, description  )				ScriptAddFunctionToClassDescNamed( pClassDesc, class, func, #func, description )
-#define ScriptAddFunctionToClassDescNamed( pClassDesc, class, func, scriptName, description ) do { ScriptFunctionBinding_t *pBinding = &((pClassDesc)->m_FunctionBindings[(pClassDesc)->m_FunctionBindings.AddToTail()]); pBinding->m_desc.m_pszDescription = description; ScriptInitMemberFunctionBindingNamed( pBinding, class, func, scriptName );  } while (0)
+#define ScriptAddFunctionToClassDescNamed( pClassDesc, class, func, scriptName, description ) do { ScriptFunctionBinding_t *pBinding = &((pClassDesc)->m_FunctionBindings[(pClassDesc)->m_FunctionBindings.AddToTail()]); pBinding->m_desc.m_pszDescription = description; ScriptInitMemberFunctionBindingNamed( pBinding, class, func, scriptName ); pBinding->m_pClassDesc = pClassDesc; } while (0)
 
 //-----------------------------------------------------------------------------
 // 


### PR DESCRIPTION
## Status

Draft. This change currently supports Linux x86-64.

## Summary

This change adds engine declarations needed by the experimental SourceMod CS2
port:

- Complete the transmit-information structures.
- Add CS2 damage flags to the shared definitions.
- Add the entity-use input type.
- Add sound-event types and sound-system interfaces.
- Add entity I/O and entity-lump metadata.
- Add visibility-cluster queries.
- Add network serializer and network-variable chainer declarations.
- Add typed economy item-system access.
- Add VProfLite historical report declarations.
- Complete the VScript function-binding layout and lookup.

## SourceMod consumers

- Transmit information is used by `SDKHook_SetTransmit`.
- Damage flags are used by SDKHooks damage calls.
- The entity-use input is used by `SDKHook_Use` and `SDKHook_UsePost`.
- Sound declarations are used by SDKTools sound emission, hooks, preload, and
  distance-gain natives.
- Entity I/O declarations are used by SDKTools output hooks and explicit
  output firing.
- Entity-lump metadata is used by the `EntityLump` native family during map
  construction.
- Serializer declarations are used for networked property changes.
- Economy access is used by the Counter-Strike weapon natives.
- Visibility queries are used by `TR_PointOutsideWorld`.
- VProfLite reports are used by SourceMod profiler natives and `sm prof`.
- VScript bindings are used by SourceMod's schema property service.

## External sources

- `public/checktransmitinfo.h`: the `vis_info_t` and
  `CCheckTransmitInfo` field layout is based on
  [Source2ZE/CS2Fixes](https://github.com/Source2ZE/CS2Fixes/blob/main/src/cs2_sdk/cchecktransmitinfo.h),
  which credits
  [Wend4r/sourcesdk](https://github.com/Wend4r/sourcesdk). The fields used by
  SourceMod were checked against Linux CS2 and tested through `SetTransmit`.
- `public/soundsystem/isoundopsystem.h`:
  [Kxnrl/ModSharp](https://github.com/Kxnrl/modsharp-public/blob/master/Engine/src/cstrike/interface/ISoundOpSystem.h)
  supplied the initial `CSoundEventManager` layout. Method order was checked
  independently in Linux CS2.
- `public/engine/IPVS.h`: method names follow the engine2 debug symbols
  published by
  [oxiKKK/sbox-dwarf](https://github.com/oxiKKK/sbox-dwarf/tree/main/dump/engine2).
  Method order used by SourceMod was checked independently in Linux CS2.
- `public/soundsystem/isoundsystem.h`:
  [bramvandammemarteel/deadlock-dumper](https://github.com/bramvandammemarteel/deadlock-dumper)
  helped locate `GetDistGainFromSoundLevel`. Its method position and call
  contract were checked independently in Linux CS2.

## Validation

- The affected headers compile in a Linux x86-64 SDK consumer.
- The SourceMod consumer builds with warnings treated as errors.
- The consumer module loads on a Linux CS2 dedicated server.
- SourceMod exercises the declarations through transmit handling, damage
  handling, sound events, entity I/O, entity use, network-state changes,
  economy access, visibility queries, profiling, VScript lookup, and entity
  lump replacement.
- Current Linux CS2 binaries and public schema data were used to check
  layouts, method order, and function behavior.

## Current limitations

- Windows layouts and behavior have not been checked.
- Unidentified virtual methods retain the established `unkNNN` naming
  convention.

## Checklist

- [x] Build a Linux x86-64 SDK consumer.
- [x] Run the consumer on a Linux dedicated server.
- [x] Keep private and partial declarations in SourceMod.
- [x] Remove public size and member-offset assertions.
- [x] Resolve the damage and physics-query placement decisions.
- [ ] Run upstream continuous-integration checks.
