### PR TITLE
ehandle: converting CHandle<T>::operator=(const CHandle<U>&)

### DIFF
--- a/game/shared/ehandle.h
+++ b/game/shared/ehandle.h
@@ -72,6 +72,14 @@ public:
 	bool	operator!=( T *val ) const;
 	const CBaseHandle& operator=( const T *val );
 
+	// Assigning a handle of another entity type (CHandle<CCSPlayerController> into a
+	// CHandle<CBaseEntity> field, say). An exact match, so it wins over the two
+	// otherwise-equal user conversions -- operator U*() into operator=( const T* )
+	// and CHandle( const CBaseHandle& ) into the copy assignment -- that made such an
+	// assignment ambiguous. Same-type assignment still takes the implicit copy.
+	template< class U >
+	CHandle<T>& operator=( const CHandle<U> &other );
+
 	T*		operator->() const;
 };
 
@@ -165,6 +173,14 @@ template<class T>
 inline const CBaseHandle& CHandle<T>::operator=( const T *val )
 {
 	Set( val );
+	return *this;
+}
+
+template<class T>
+template<class U>
+inline CHandle<T>& CHandle<T>::operator=( const CHandle<U> &other )
+{
+	Init( other.GetEntryIndex(), other.GetSerialNumber() );
 	return *this;
 }
 


### PR DESCRIPTION
## Problem

Assigning a `CHandle<Derived>` to a `CHandle<Base>` is ambiguous:

```cpp
CHandle<CBaseEntity> owner;               // e.g. a schema field
CHandle<CCSPlayerController> player = ...;
owner = player;                           // error: ambiguous operator call
```

Two user-defined conversion sequences rank equally:

- `CHandle<U>::operator U*()` into `CHandle<T>::operator=(const T*)`
- `CHandle<T>(const CBaseHandle&)` into the implicit copy assignment

Copy-initialization (`CHandle<CBaseEntity> h = player;`) is fine because only one user-defined conversion may take part there; it is plain assignment that breaks.

## Fix

Add a converting assignment template to `CHandle<T>`:

```cpp
template< class U >
CHandle<T>& operator=( const CHandle<U> &other );   // Init( other.GetEntryIndex(), other.GetSerialNumber() )
```

It is an exact match, so it wins over both conversions. Same-type assignment still takes the implicit copy assignment, since a non-template is preferred over a template. Behaviour otherwise matches what `CHandle<T>(const CBaseHandle&)` already allows on construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)